### PR TITLE
Scope server-specific vars and secrets to production environment

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -22,4 +22,9 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
+      - name: Install ansible and collections
+        run: |
+          pip install ansible ansible-lint
+          ansible-galaxy collection install -r requirements.yml
+          ansible-galaxy role install -r requirements.yml
       - uses: pre-commit/action@v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,5 +50,5 @@ repos:
     rev: v26.2.0 # put latest release tag from https://github.com/ansible-community/ansible-lint/releases/
     hooks:
       - id: ansible-lint
-        entry: python3 -m ansiblelint -v --force-color --fix --offline
+        entry: python3 -m ansiblelint -v --force-color --fix
         files: \.(yaml|yml)$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,5 +50,5 @@ repos:
     rev: v26.2.0 # put latest release tag from https://github.com/ansible-community/ansible-lint/releases/
     hooks:
       - id: ansible-lint
-        entry: python3 -m ansiblelint -v --force-color --fix
+        entry: python3 -m ansiblelint -v --force-color --fix --offline
         files: \.(yaml|yml)$

--- a/roles/stream_delta/defaults/main.yml
+++ b/roles/stream_delta/defaults/main.yml
@@ -1,14 +1,22 @@
 ---
 # Stream Delta role defaults
 
-# GitHub Actions Variables to set
+stream_delta_github_environment: production
+
+# GitHub Actions repository-level variables (not environment-specific)
 stream_delta_github_variables:
+  - { name: "PHP_VERSION", value: "{{ php_version }}" }
+  - { name: "NODE_VERSION", value: "{{ stream_delta_node_version }}" }
+  - { name: "STREAM_DELTA_TWITCH_BROADCASTER_ID", value: "{{ stream_delta_twitch_broadcaster_id }}" }
+  - { name: "STREAM_DELTA_TWITCH_BROADCASTER_NAME", value: "{{ stream_delta_twitch_broadcaster_name }}" }
+  - { name: "DEPLOYED_TAG", value: "ansible_deploy" }
+
+# GitHub Actions production environment variables (server-specific)
+stream_delta_github_production_variables:
   - { name: "DEPLOY_HOST", value: "{{ atoll_ip }}" }
   - { name: "DEPLOY_PATH", value: "{{ stream_delta_install_dir }}" }
   - { name: "DEPLOY_PORT", value: "22" }
   - { name: "DEPLOY_USER", value: "stream-delta" }
-  - { name: "PHP_VERSION", value: "{{ php_version }}" }
-  - { name: "NODE_VERSION", value: "{{ stream_delta_node_version }}" }
   - { name: "STREAM_DELTA_APP_URL", value: "{{ stream_delta_app_url }}" }
   - { name: "STREAM_DELTA_DB_HOST", value: "{{ stream_delta_db_host }}" }
   - { name: "STREAM_DELTA_DB_NAME", value: "{{ stream_delta_db_name }}" }
@@ -19,29 +27,19 @@ stream_delta_github_variables:
   - { name: "STREAM_DELTA_REDIS_USERNAME", value: "{{ stream_delta_redis_username }}" }
   - { name: "STREAM_DELTA_YOUTUBE_CHANNEL_ID", value: "{{ stream_delta_youtube_channel_id }}" }
   - { name: "STREAM_DELTA_TUBULAR_CALLBACK_PORT", value: "{{ stream_delta_tubular_port }}" }
-  - { name: "STREAM_DELTA_TWITCH_BROADCASTER_ID", value: "{{ stream_delta_twitch_broadcaster_id }}" }
-  - { name: "STREAM_DELTA_TWITCH_BROADCASTER_NAME", value: "{{ stream_delta_twitch_broadcaster_name }}" }
   - { name: "STREAM_DELTA_AWS_DEFAULT_REGION", value: "{{ stream_delta_aws_region }}" }
   - { name: "STREAM_DELTA_AWS_BUCKET", value: "{{ stream_delta_aws_bucket }}" }
   - { name: "STREAM_DELTA_AWS_URL", value: "{{ stream_delta_aws_url }}" }
   - { name: "STREAM_DELTA_TELESCOPE_ENABLED", value: "false" }
-  - { name: "DEPLOYED_TAG", value: "ansible_deploy" }
 
 stream_delta_aws_iam_user: stream-delta-logos
 stream_delta_aws_url: "https://{{ stream_delta_aws_bucket }}.s3.{{ stream_delta_aws_region }}.amazonaws.com"
 
-# GitHub Actions Secrets to set
+# GitHub Actions repository-level secrets (not environment-specific)
 stream_delta_github_secrets:
-  - { name: "STREAM_DELTA_DB_PASSWORD", value: "{{ stream_delta_db_password }}" }
-  - { name: "STREAM_DELTA_APP_KEY", value: "{{ stream_delta_app_key }}" }
-  - { name: "STREAM_DELTA_WEBHOOK_SECRET", value: "{{ stream_delta_webhook_secret }}" }
+  - { name: "DEPENDABOT_GITHUB_TOKEN", value: "{{ streamdelta_github_token }}" }
   - { name: "STREAM_DELTA_TWITCH_CLIENT_ID", value: "{{ stream_delta_twitch_client_id }}" }
   - { name: "STREAM_DELTA_TWITCH_CLIENT_SECRET", value: "{{ stream_delta_twitch_client_secret }}" }
-  - { name: "SSH_KEY", value: '{{ lookup("ansible.builtin.file", "files/keys/stream-delta-deploy") }}' }
-  - { name: "STREAM_DELTA_REVERB_APP_KEY", value: "{{ stream_delta_reverb_app_key }}" }
-  - { name: "STREAM_DELTA_REVERB_APP_SECRET", value: "{{ stream_delta_reverb_app_secret }}" }
-  - { name: "STREAM_DELTA_REDIS_PASSWORD", value: "{{ stream_delta_redis_password }}" }
-  - { name: "DEPENDABOT_GITHUB_TOKEN", value: "{{ streamdelta_github_token }}" }
   - { name: "STREAM_DELTA_YOUTUBE_API_KEY", value: "{{ stream_delta_youtube_api_key }}" }
   - { name: "STREAM_DELTA_STEAMGRIDDB_API_KEY", value: "{{ stream_delta_steamgriddb_api_key }}" }
   - { name: "STREAM_DELTA_KOFI_WEBHOOK_SECRET", value: "{{ stream_delta_kofi_webhook_secret }}" }
@@ -50,3 +48,13 @@ stream_delta_github_secrets:
   - { name: "STREAM_DELTA_DISCORD_CLIENT_ID", value: "{{ stream_delta_discord_client_id }}" }
   - { name: "STREAM_DELTA_DISCORD_CLIENT_SECRET", value: "{{ stream_delta_discord_client_secret }}" }
   - { name: "STREAM_DELTA_DISCORD_BOT_TOKEN", value: "{{ stream_delta_discord_bot_token }}" }
+
+# GitHub Actions production environment secrets (server-specific)
+stream_delta_github_production_secrets:
+  - { name: "SSH_KEY", value: '{{ lookup("ansible.builtin.file", "files/keys/stream-delta-deploy") }}' }
+  - { name: "STREAM_DELTA_DB_PASSWORD", value: "{{ stream_delta_db_password }}" }
+  - { name: "STREAM_DELTA_APP_KEY", value: "{{ stream_delta_app_key }}" }
+  - { name: "STREAM_DELTA_WEBHOOK_SECRET", value: "{{ stream_delta_webhook_secret }}" }
+  - { name: "STREAM_DELTA_REVERB_APP_KEY", value: "{{ stream_delta_reverb_app_key }}" }
+  - { name: "STREAM_DELTA_REVERB_APP_SECRET", value: "{{ stream_delta_reverb_app_secret }}" }
+  - { name: "STREAM_DELTA_REDIS_PASSWORD", value: "{{ stream_delta_redis_password }}" }

--- a/roles/stream_delta/tasks/main.yml
+++ b/roles/stream_delta/tasks/main.yml
@@ -536,9 +536,13 @@
       register: stream_delta_env_response
       changed_when: stream_delta_env_response.status == 201
 
+    - name: Set api_endpoint for production environment variables
+      ansible.builtin.set_fact:
+        stream_delta_gh_env_api: "https://api.github.com/repos/aquarion/stream-delta/environments/{{ stream_delta_github_environment }}"
+
     - name: Get list of production environment variables
       ansible.builtin.uri:
-        url: "https://api.github.com/repos/aquarion/stream-delta/environments/{{ stream_delta_github_environment }}/variables?per_page=30"
+        url: "{{ stream_delta_gh_env_api }}/variables?per_page=30"
         method: GET
         headers:
           Accept: "application/vnd.github.v3+json"
@@ -554,8 +558,7 @@
 
     - name: Add variables to production environment
       ansible.builtin.uri:
-        url: "https://api.github.com/repos/aquarion/stream-delta/environments/{{ stream_delta_github_environment }}/variables{{ ('/' + item.name) if item.name in
-          stream_delta_production_vars else '' }}"
+        url: "{{ stream_delta_gh_env_api }}/variables{{ ('/' + item.name) if item.name in stream_delta_production_vars else '' }}"
         method: "{{ 'PATCH' if item.name in stream_delta_production_vars else 'POST' }}"
         headers:
           Authorization: "Bearer {{ streamdelta_github_token }}"
@@ -572,7 +575,7 @@
 
     - name: Get github public key for production environment
       ansible.builtin.uri:
-        url: "https://api.github.com/repos/aquarion/stream-delta/environments/{{ stream_delta_github_environment }}/secrets/public-key"
+        url: "{{ stream_delta_gh_env_api }}/secrets/public-key"
         method: GET
         headers:
           Accept: "application/vnd.github.v3+json"
@@ -584,7 +587,7 @@
 
     - name: Add secrets to production environment
       ansible.builtin.uri:
-        url: "https://api.github.com/repos/aquarion/stream-delta/environments/{{ stream_delta_github_environment }}/secrets/{{ item.name }}"
+        url: "{{ stream_delta_gh_env_api }}/secrets/{{ item.name }}"
         method: PUT
         headers:
           Authorization: "Bearer {{ streamdelta_github_token }}"

--- a/roles/stream_delta/tasks/main.yml
+++ b/roles/stream_delta/tasks/main.yml
@@ -437,7 +437,6 @@
     - name: Add variables to github actions workflow
       ansible.builtin.uri:
         url: "https://api.github.com/repos/aquarion/stream-delta/actions/variables{{ ('/' + item.name) if item.name in stream_delta_vars else '' }}"
-
         method: "{{ 'PATCH' if item.name in stream_delta_vars else 'POST' }}"
         headers:
           Authorization: "Bearer {{ streamdelta_github_token }}"
@@ -452,6 +451,20 @@
       changed_when: stream_delta_response.status == 201
       loop: "{{ stream_delta_github_variables }}"
 
+    - name: Remove production-scoped variables from repository scope
+      ansible.builtin.uri:
+        url: "https://api.github.com/repos/aquarion/stream-delta/actions/variables/{{ item.name }}"
+        method: DELETE
+        headers:
+          Authorization: "Bearer {{ streamdelta_github_token }}"
+          Accept: "application/vnd.github.v3+json"
+          X-GitHub-Api-Version: "2022-11-28"
+        status_code: 204,404
+      register: stream_delta_delete_var_response
+      changed_when: stream_delta_delete_var_response.status == 204
+      when: item.name in stream_delta_vars
+      loop: "{{ stream_delta_github_production_variables }}"
+
     - name: Get github public key for stream-delta repository
       ansible.builtin.uri:
         url: "https://api.github.com/repos/aquarion/stream-delta/actions/secrets/public-key"
@@ -465,7 +478,6 @@
       changed_when: false
 
     - name: Add secrets to stream-delta github repository
-
       ansible.builtin.uri:
         url: "https://api.github.com/repos/aquarion/stream-delta/actions/secrets/{{ item.name }}"
         method: PUT
@@ -482,6 +494,111 @@
       changed_when: stream_delta_secrets_response.status == 201
       no_log: true
       loop: "{{ stream_delta_github_secrets }}"
+
+    - name: Get list of repository secrets
+      ansible.builtin.uri:
+        url: "https://api.github.com/repos/aquarion/stream-delta/actions/secrets?per_page=30"
+        method: GET
+        headers:
+          Accept: "application/vnd.github.v3+json"
+          Authorization: "Bearer {{ streamdelta_github_token }}"
+          X-GitHub-Api-Version: "2022-11-28"
+        return_content: true
+      register: stream_delta_github_secrets_response
+      changed_when: false
+
+    - name: Remove production-scoped secrets from repository scope
+      ansible.builtin.uri:
+        url: "https://api.github.com/repos/aquarion/stream-delta/actions/secrets/{{ item.name }}"
+        method: DELETE
+        headers:
+          Authorization: "Bearer {{ streamdelta_github_token }}"
+          Accept: "application/vnd.github.v3+json"
+          X-GitHub-Api-Version: "2022-11-28"
+        status_code: 204,404
+      register: stream_delta_delete_secret_response
+      changed_when: stream_delta_delete_secret_response.status == 204
+      no_log: true
+      when: item.name in (stream_delta_github_secrets_response.json.secrets | map(attribute='name') | list)
+      loop: "{{ stream_delta_github_production_secrets }}"
+
+    - name: Ensure production environment exists
+      ansible.builtin.uri:
+        url: "https://api.github.com/repos/aquarion/stream-delta/environments/{{ stream_delta_github_environment }}"
+        method: PUT
+        headers:
+          Authorization: "Bearer {{ streamdelta_github_token }}"
+          Accept: "application/vnd.github.v3+json"
+          X-GitHub-Api-Version: "2022-11-28"
+        body: {}
+        body_format: json
+        status_code: 200,201
+      register: stream_delta_env_response
+      changed_when: stream_delta_env_response.status == 201
+
+    - name: Get list of production environment variables
+      ansible.builtin.uri:
+        url: "https://api.github.com/repos/aquarion/stream-delta/environments/{{ stream_delta_github_environment }}/variables?per_page=30"
+        method: GET
+        headers:
+          Accept: "application/vnd.github.v3+json"
+          Authorization: "Bearer {{ streamdelta_github_token }}"
+          X-GitHub-Api-Version: "2022-11-28"
+        return_content: true
+      register: stream_delta_github_production_variables_response
+      changed_when: false
+
+    - name: Set production variables list as fact for cleaner code
+      ansible.builtin.set_fact:
+        stream_delta_production_vars: "{{ stream_delta_github_production_variables_response.json.variables | map(attribute='name') | list }}"
+
+    - name: Add variables to production environment
+      ansible.builtin.uri:
+        url: "https://api.github.com/repos/aquarion/stream-delta/environments/{{ stream_delta_github_environment }}/variables{{ ('/' + item.name) if item.name in
+          stream_delta_production_vars else '' }}"
+        method: "{{ 'PATCH' if item.name in stream_delta_production_vars else 'POST' }}"
+        headers:
+          Authorization: "Bearer {{ streamdelta_github_token }}"
+          Accept: "application/vnd.github.v3+json"
+          X-GitHub-Api-Version: "2022-11-28"
+        body:
+          name: "{{ item.name }}"
+          value: "{{ item.value | string }}"
+        body_format: json
+        status_code: 200,201,204
+      register: stream_delta_production_response
+      changed_when: stream_delta_production_response.status == 201
+      loop: "{{ stream_delta_github_production_variables }}"
+
+    - name: Get github public key for production environment
+      ansible.builtin.uri:
+        url: "https://api.github.com/repos/aquarion/stream-delta/environments/{{ stream_delta_github_environment }}/secrets/public-key"
+        method: GET
+        headers:
+          Accept: "application/vnd.github.v3+json"
+          Authorization: "Bearer {{ streamdelta_github_token }}"
+          X-GitHub-Api-Version: "2022-11-28"
+        return_content: true
+      register: stream_delta_github_production_public_key
+      changed_when: false
+
+    - name: Add secrets to production environment
+      ansible.builtin.uri:
+        url: "https://api.github.com/repos/aquarion/stream-delta/environments/{{ stream_delta_github_environment }}/secrets/{{ item.name }}"
+        method: PUT
+        headers:
+          Authorization: "Bearer {{ streamdelta_github_token }}"
+          Accept: "application/vnd.github.v3+json"
+          X-GitHub-Api-Version: "2022-11-28"
+        body:
+          encrypted_value: "{{ item.value | encrypt_secret(stream_delta_github_production_public_key.json.key) }}"
+          key_id: "{{ stream_delta_github_production_public_key.json.key_id }}"
+        body_format: json
+        status_code: 200,201,204
+      register: stream_delta_production_secrets_response
+      changed_when: stream_delta_production_secrets_response.status == 201
+      no_log: true
+      loop: "{{ stream_delta_github_production_secrets }}"
 
     # - name: Trigger github action to deploy stream-delta
     #   ansible.builtin.uri:
@@ -541,7 +658,7 @@
     - name: Set template variables as individual facts
       ansible.builtin.set_fact:
         "{{ item.name }}": "{{ item.value }}"
-      loop: "{{ stream_delta_github_variables + stream_delta_github_secrets }}"
+      loop: "{{ stream_delta_github_variables + stream_delta_github_production_variables + stream_delta_github_secrets + stream_delta_github_production_secrets }}"
 
     - name: Create .env file for stream-delta using fetched template
       ansible.builtin.template:
@@ -554,7 +671,7 @@
     - name: Clean up template variables from facts
       ansible.builtin.set_fact:
         "{{ item.name }}":
-      loop: "{{ stream_delta_github_variables + stream_delta_github_secrets }}"
+      loop: "{{ stream_delta_github_variables + stream_delta_github_production_variables + stream_delta_github_secrets + stream_delta_github_production_secrets }}"
 
     - name: Clean up temporary template file
       ansible.builtin.file:


### PR DESCRIPTION
## Summary
- Splits `stream_delta_github_variables` and `stream_delta_github_secrets` into repo-level and production environment-scoped lists
- Server-specific items (deploy targets, DB, Redis, Reverb, app key, SSH key) are now set on the GitHub Actions `production` environment instead of at the repo level
- Adds tasks to delete production-scoped items from the repo level after migrating them
- Adds `--offline` flag to ansible-lint pre-commit hook to speed up runs

## Test plan
- [ ] Run playbook against atoll — verify production environment variables and secrets are set in GitHub
- [ ] Verify repo-level vars/secrets that were migrated are removed from repo scope
- [ ] Confirm stream-delta deploy workflow still has access to all required vars/secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)