### PR TITLE
🐦‍🔥 Pin and upgrade Ansible collections to latest versions

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -1,10 +1,17 @@
 ---
 collections:
-  - amazon.aws
-  - community.general
-  - ansible.mysql
-  - community.crypto
-  - community.docker
-  - ansible.posix
+  - name: amazon.aws
+    version: "11.3.0"
+  - name: community.general
+    version: "13.0.0"
+  - name: ansible.mysql
+    version: "5.0.1"
+  - name: community.crypto
+    version: "3.2.1"
+  - name: community.docker
+    version: "5.2.0"
+  - name: ansible.posix
+    version: "2.2.0"
 roles:
   - name: geerlingguy.nodejs
+    version: "7.1.0"


### PR DESCRIPTION
## Summary

- Pins all Ansible collections and roles to explicit versions for reproducible CI
- Upgrades all dependencies to their latest releases

| Collection | Old | New |
|---|---|---|
| `amazon.aws` | unpinned | 11.3.0 |
| `community.general` | unpinned | 13.0.0 |
| `ansible.mysql` | unpinned | 5.0.1 |
| `community.crypto` | unpinned | 3.2.1 |
| `community.docker` | unpinned | 5.2.0 |
| `ansible.posix` | unpinned | 2.2.0 |
| `geerlingguy.nodejs` | unpinned | 7.1.0 |

## Breaking change analysis

**amazon.aws v11**: `iam_user` return key renamed `iam_user` → `user` — registered in `s3_iam.yml` but result is never accessed, no impact. All other breaking changes affect unused modules (`s3_object` list mode, `route53_info` CamelCase keys, etc.).

**community.general v13**: Breaking changes affect `github_repo`, `rocketchat`, `onepassword` lookups, and removed legacy modules — none used in this repo.

**community.crypto 3.2.1** and **ansible.posix 2.2.0**: Bugfix releases only, no breaking changes.

## Test plan

- [ ] CI pre-commit passes
- [ ] ansible-lint passes with new collection versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)