### PR TITLE
🎇 Add docket deployment config and additional_env support

### DIFF
--- a/host_vars/firth.water.gkhs.net/laravel_apps.yml
+++ b/host_vars/firth.water.gkhs.net/laravel_apps.yml
@@ -146,3 +146,56 @@ firth_laravel_app_apps:
       redis:
         username: sprouter_staging
         password: "{{ vault_sprouter_staging_redis_password }}"
+
+  - name: docket
+    image: ghcr.io/aquarion/docket
+    image_tag: latest
+    backend: fpm
+    port: 9003
+    server_name: docket.hubris.house
+    app_url: https://docket.hubris.house
+    app_key: "{{ vault_docket_app_key }}"
+    app_name: Docket
+    ssl_snippet: hubris
+    github_repo: aquarion/docket
+    github_deploy_token: "{{ laravel_apps_deploy_token_aquarion }}"
+    ghcr_username: "{{ ghcr_username }}"
+    ghcr_token: "{{ ghcr_token }}"
+    mysql:
+      db_name: docket
+      db_user: docket
+      db_password: "{{ vault_docket_db_password }}"
+    redis:
+      username: docket
+      password: "{{ vault_docket_redis_password }}"
+    additional_env:
+      MY_LAT: "{{ vault_docket_my_lat }}"
+      MY_LON: "{{ vault_docket_my_lon }}"
+      MAPBOX_API_TOKEN: "{{ vault_docket_mapbox_token }}"
+      GOOGLE_CREDENTIALS_PATH: google/credentials.json
+      GOOGLE_REDIRECT_URI: https://docket.hubris.house/token
+      GOOGLE_DEFAULT_ACCOUNT: "{{ vault_docket_google_default_account }}"
+      CALENDAR_CACHE_TTL: "900"
+      GCAL_HOLIDAYS_SRC: "{{ vault_docket_gcal_holidays_src }}"
+      GCAL_WORK_SRC: "{{ vault_docket_gcal_work_src }}"
+      GCAL_PERSONAL_SRC: "{{ vault_docket_gcal_personal_src }}"
+      GCAL_FAMILY_SRC: "{{ vault_docket_gcal_family_src }}"
+      ICAL_WORK_URL: "{{ vault_docket_ical_work_url }}"
+      ICAL_BIRTHDAYS_URL: "{{ vault_docket_ical_birthdays_url }}"
+      ICAL_DEADLINES_URL: "{{ vault_docket_ical_deadlines_url }}"
+    staging:
+      image_tag: staging
+      port: 9004
+      server_name: docket.istic.dev
+      app_url: https://docket.istic.dev
+      app_key: "{{ vault_docket_staging_app_key }}"
+      ssl_snippet: istic_dev
+      mysql:
+        db_name: docket_staging
+        db_user: docket_staging
+        db_password: "{{ vault_docket_staging_db_password }}"
+      redis:
+        username: docket_staging
+        password: "{{ vault_docket_staging_redis_password }}"
+      additional_env:
+        GOOGLE_REDIRECT_URI: https://docket.istic.dev/token

--- a/roles/firth_laravel_app/tasks/app.yml
+++ b/roles/firth_laravel_app/tasks/app.yml
@@ -21,6 +21,7 @@
       mysql: "{{ firth_laravel_app_item.mysql | default({}) }}"
       redis: "{{ firth_laravel_app_item.redis | default({}) }}"
       mail: "{{ firth_laravel_app_item.mail | default({}) }}"
+      additional_env: "{{ firth_laravel_app_item.additional_env | default({}) }}"
       system_user: "{{ firth_laravel_app_item.name }}"
   tags: [always, firth_laravel_app]
 

--- a/roles/firth_laravel_app/tasks/staging.yml
+++ b/roles/firth_laravel_app/tasks/staging.yml
@@ -38,6 +38,7 @@
       mysql: "{{ fla.staging.mysql | default({}) }}"
       redis: "{{ fla.staging.redis | default({}) }}"
       mail: "{{ fla.mail | default({}) }}"
+      additional_env: "{{ fla.staging.additional_env | default(fla.additional_env | default({})) }}"
       system_user: "{{ fla.name }}"
   tags: firth_laravel_app
 


### PR DESCRIPTION
This pull request adds support for deploying a new Laravel application called `docket` to the configuration, including both production and staging environments. It also updates the deployment tasks to handle additional environment variables for all Laravel apps.

**New application configuration:**

* Added a full configuration for the new `docket` Laravel app in `host_vars/firth.water.gkhs.net/laravel_apps.yml`, including image details, environment variables, and separate production and staging settings.

**Deployment task enhancements:**

* Updated `roles/firth_laravel_app/tasks/app.yml` to support an `additional_env` dictionary for each app, allowing the injection of extra environment variables during deployment.
* Modified `roles/firth_laravel_app/tasks/staging.yml` to support `additional_env` for staging environments, falling back to the main app's `additional_env` if not specified.