### PR TITLE
🎇 firth_laravel_app: add additional_volumes support + thalium provisioning

### DIFF
--- a/host_vars/firth.water.gkhs.net/laravel_apps.yml
+++ b/host_vars/firth.water.gkhs.net/laravel_apps.yml
@@ -116,7 +116,7 @@ firth_laravel_app_apps:
     ssl_snippet: bloomfeedapp
     github_repo: aquarion/bloom
     github_deploy_token: "{{ laravel_apps_deploy_token_aquarion }}"
-    github_rebase_token: "{{ laravel_apps_rebase_token_aquarion }}"
+    github_rebase_token: "{{ laravel_apps_rebase_token }}"
     ghcr_username: "{{ ghcr_username }}"
     ghcr_token: "{{ ghcr_token }}"
     mysql:
@@ -276,7 +276,7 @@ firth_laravel_app_apps:
     ssl_snippet: aquarionics
     github_repo: aquarion/thalium
     github_deploy_token: "{{ laravel_apps_deploy_token_aquarion }}"
-    github_rebase_token: "{{ laravel_apps_rebase_token_aquarion }}"
+    github_rebase_token: "{{ laravel_apps_rebase_token }}"
     ghcr_username: "{{ ghcr_username }}"
     ghcr_token: "{{ ghcr_token }}"
     worker: true

--- a/host_vars/firth.water.gkhs.net/laravel_apps.yml
+++ b/host_vars/firth.water.gkhs.net/laravel_apps.yml
@@ -116,7 +116,6 @@ firth_laravel_app_apps:
     ssl_snippet: bloomfeedapp
     github_repo: aquarion/bloom
     github_deploy_token: "{{ laravel_apps_deploy_token_aquarion }}"
-    github_rebase_token: "{{ laravel_apps_rebase_token }}"
     ghcr_username: "{{ ghcr_username }}"
     ghcr_token: "{{ ghcr_token }}"
     mysql:
@@ -276,7 +275,6 @@ firth_laravel_app_apps:
     ssl_snippet: aquarionics
     github_repo: aquarion/thalium
     github_deploy_token: "{{ laravel_apps_deploy_token_aquarion }}"
-    github_rebase_token: "{{ laravel_apps_rebase_token }}"
     ghcr_username: "{{ ghcr_username }}"
     ghcr_token: "{{ ghcr_token }}"
     worker: true

--- a/host_vars/firth.water.gkhs.net/laravel_apps.yml
+++ b/host_vars/firth.water.gkhs.net/laravel_apps.yml
@@ -116,6 +116,7 @@ firth_laravel_app_apps:
     ssl_snippet: bloomfeedapp
     github_repo: aquarion/bloom
     github_deploy_token: "{{ laravel_apps_deploy_token_aquarion }}"
+    github_rebase_token: "{{ laravel_apps_rebase_token_aquarion }}"
     ghcr_username: "{{ ghcr_username }}"
     ghcr_token: "{{ ghcr_token }}"
     mysql:
@@ -275,6 +276,7 @@ firth_laravel_app_apps:
     ssl_snippet: aquarionics
     github_repo: aquarion/thalium
     github_deploy_token: "{{ laravel_apps_deploy_token_aquarion }}"
+    github_rebase_token: "{{ laravel_apps_rebase_token_aquarion }}"
     ghcr_username: "{{ ghcr_username }}"
     ghcr_token: "{{ ghcr_token }}"
     worker: true

--- a/host_vars/firth.water.gkhs.net/laravel_apps.yml
+++ b/host_vars/firth.water.gkhs.net/laravel_apps.yml
@@ -255,3 +255,61 @@ firth_laravel_app_apps:
       additional_files:
         - src: files/laravel/wereabouts/google_credentials.vault.json
           dest: google/credentials.json
+
+  # Vault variables required (add to vault manually):
+  #   vault_thalium_app_key
+  #   vault_thalium_staging_app_key
+  #   vault_thalium_redis_password
+  #   vault_thalium_staging_redis_password
+  #   vault_thalium_es_user
+  #   vault_thalium_es_pass
+  - name: thalium
+    image: ghcr.io/aquarion/thalium
+    image_tag: latest
+    backend: octane
+    port: 8002
+    server_name: thalium.aquarionics.com
+    app_url: https://thalium.aquarionics.com
+    app_key: "{{ vault_thalium_app_key }}"
+    app_name: Thalium
+    ssl_snippet: aquarionics
+    github_repo: aquarion/thalium
+    github_deploy_token: "{{ laravel_apps_deploy_token_aquarion }}"
+    ghcr_username: "{{ ghcr_username }}"
+    ghcr_token: "{{ ghcr_token }}"
+    worker: true
+    redis:
+      username: thalium
+      password: "{{ vault_thalium_redis_password }}"
+    additional_env:
+      ELASTICSEARCH_HOST: host.docker.internal
+      ELASTICSEARCH_PORT: "9200"
+      ELASTICSEARCH_SCHEME: https
+      ELASTICSEARCH_USER: "{{ vault_thalium_es_user }}"
+      ELASTICSEARCH_PASS: "{{ vault_thalium_es_pass }}"
+      DOCKER_PDF_LIBRARY: /mnt/rpg
+      LIBRARY_URL: https://thalium.aquarionics.com/_libris/
+    additional_volumes:
+      - src: /home/library/RPG/Systems
+        dest: /mnt/rpg
+      - name: elasticsearch_certs
+        dest: /usr/share/elasticsearch/config/certs
+        external: true
+    staging:
+      image_tag: staging
+      port: 8003
+      server_name: thalium.istic.dev
+      app_url: https://thalium.istic.dev
+      app_key: "{{ vault_thalium_staging_app_key }}"
+      ssl_snippet: istic_dev
+      redis:
+        username: thalium_staging
+        password: "{{ vault_thalium_staging_redis_password }}"
+      additional_env:
+        ELASTICSEARCH_HOST: host.docker.internal
+        ELASTICSEARCH_PORT: "9200"
+        ELASTICSEARCH_SCHEME: https
+        ELASTICSEARCH_USER: "{{ vault_thalium_es_user }}"
+        ELASTICSEARCH_PASS: "{{ vault_thalium_es_pass }}"
+        DOCKER_PDF_LIBRARY: /mnt/rpg
+        LIBRARY_URL: https://thalium.istic.dev/_libris/

--- a/roles/firth_laravel_app/tasks/app.yml
+++ b/roles/firth_laravel_app/tasks/app.yml
@@ -36,6 +36,11 @@
   ansible.builtin.include_tasks: system_user.yml
   tags: [firth_laravel_app, firth_laravel_app_install]
 
+- name: Configure GitHub Actions secrets for {{ fla.name }}
+  ansible.builtin.include_tasks: github.yml
+  when: fla.github_repo is defined and fla.github_rebase_token is defined
+  tags: [firth_laravel_app, firth_laravel_app_install]
+
 - name: Provision database for {{ fla.name }}
   ansible.builtin.include_tasks: mysql.yml
   when: fla_ctx.mysql | length > 0

--- a/roles/firth_laravel_app/tasks/app.yml
+++ b/roles/firth_laravel_app/tasks/app.yml
@@ -38,7 +38,7 @@
 
 - name: Configure GitHub Actions secrets for {{ fla.name }}
   ansible.builtin.include_tasks: github.yml
-  when: fla.github_repo is defined and fla.github_rebase_token is defined
+  when: fla.github_repo is defined
   tags: [firth_laravel_app, firth_laravel_app_install]
 
 - name: Provision database for {{ fla.name }}

--- a/roles/firth_laravel_app/tasks/app.yml
+++ b/roles/firth_laravel_app/tasks/app.yml
@@ -23,6 +23,7 @@
       mail: "{{ firth_laravel_app_item.mail | default({}) }}"
       additional_env: "{{ firth_laravel_app_item.additional_env | default({}) }}"
       additional_files: "{{ firth_laravel_app_item.additional_files | default([]) }}"
+      additional_volumes: "{{ firth_laravel_app_item.additional_volumes | default([]) }}"
       system_user: "{{ firth_laravel_app_item.name }}"
   tags: [always, firth_laravel_app, firth_laravel_app_install]
 

--- a/roles/firth_laravel_app/tasks/github.yml
+++ b/roles/firth_laravel_app/tasks/github.yml
@@ -1,0 +1,36 @@
+---
+- name: Get GitHub public key for repository {{ fla.github_repo }}
+  ansible.builtin.uri:
+    url: "https://api.github.com/repos/{{ fla.github_repo }}/actions/secrets/public-key"
+    method: GET
+    headers:
+      Accept: "application/vnd.github.v3+json"
+      Authorization: "Bearer {{ fla.github_deploy_token }}"
+      X-GitHub-Api-Version: "2022-11-28"
+    return_content: true
+  register: firth_laravel_app_github_pubkey
+  delegate_to: localhost
+  become: false
+  changed_when: false
+  no_log: true
+  when: not ansible_check_mode
+
+- name: Upload REBASE_TOKEN to GitHub Actions secrets for {{ fla.github_repo }}
+  ansible.builtin.uri:
+    url: "https://api.github.com/repos/{{ fla.github_repo }}/actions/secrets/REBASE_TOKEN"
+    method: PUT
+    headers:
+      Authorization: "Bearer {{ fla.github_deploy_token }}"
+      Accept: "application/vnd.github.v3+json"
+      X-GitHub-Api-Version: "2022-11-28"
+    body:
+      encrypted_value: "{{ fla.github_rebase_token | encrypt_secret(firth_laravel_app_github_pubkey.json.key) }}"
+      key_id: "{{ firth_laravel_app_github_pubkey.json.key_id }}"
+    body_format: json
+    status_code: [200, 201, 204]
+  register: firth_laravel_app_github_rebase_response
+  delegate_to: localhost
+  become: false
+  changed_when: firth_laravel_app_github_rebase_response.status == 201
+  no_log: true
+  when: not ansible_check_mode

--- a/roles/firth_laravel_app/tasks/github.yml
+++ b/roles/firth_laravel_app/tasks/github.yml
@@ -24,7 +24,7 @@
       Accept: "application/vnd.github.v3+json"
       X-GitHub-Api-Version: "2022-11-28"
     body:
-      encrypted_value: "{{ fla.github_rebase_token | encrypt_secret(firth_laravel_app_github_pubkey.json.key) }}"
+      encrypted_value: "{{ laravel_apps_rebase_token | encrypt_secret(firth_laravel_app_github_pubkey.json.key) }}"
       key_id: "{{ firth_laravel_app_github_pubkey.json.key_id }}"
     body_format: json
     status_code: [200, 201, 204]

--- a/roles/firth_laravel_app/tasks/staging.yml
+++ b/roles/firth_laravel_app/tasks/staging.yml
@@ -52,6 +52,7 @@
       mail: "{{ fla.mail | default({}) }}"
       additional_env: "{{ fla.staging.additional_env | default(fla.additional_env | default({})) }}"
       additional_files: "{{ fla.staging.additional_files | default(fla.additional_files | default([])) }}"
+      additional_volumes: "{{ fla.staging.additional_volumes | default(fla.additional_volumes | default([])) }}"
       system_user: "{{ fla.name }}"
   tags: [firth_laravel_app, firth_laravel_app_install]
 

--- a/roles/firth_laravel_app/templates/docker-compose.yml.j2
+++ b/roles/firth_laravel_app/templates/docker-compose.yml.j2
@@ -49,6 +49,13 @@ services:
 {% for file in fla_ctx.additional_files %}
       - {{ docker_root }}/{{ fla_ctx.name }}/secrets/{{ file.dest }}:{{ fla_ctx.workdir }}/storage/app/{{ file.dest }}:ro
 {% endfor %}
+{% for vol in fla_ctx.additional_volumes %}
+{% if vol.src is defined %}
+      - {{ vol.src }}:{{ vol.dest }}
+{% else %}
+      - {{ vol.name }}:{{ vol.dest }}
+{% endif %}
+{% endfor %}
     extra_hosts:
       - "host.docker.internal:host-gateway"
     networks:
@@ -69,6 +76,13 @@ services:
 {% for file in fla_ctx.additional_files %}
       - {{ docker_root }}/{{ fla_ctx.name }}/secrets/{{ file.dest }}:{{ fla_ctx.workdir }}/storage/app/{{ file.dest }}:ro
 {% endfor %}
+{% for vol in fla_ctx.additional_volumes %}
+{% if vol.src is defined %}
+      - {{ vol.src }}:{{ vol.dest }}
+{% else %}
+      - {{ vol.name }}:{{ vol.dest }}
+{% endif %}
+{% endfor %}
     extra_hosts:
       - "host.docker.internal:host-gateway"
     networks:
@@ -82,6 +96,15 @@ services:
 volumes:
   storage:
 
+{% for vol in fla_ctx.additional_volumes %}
+{% if vol.name is defined %}
+  {{ vol.name }}:
+{% if vol.external | default(false) %}
+    external: true
+    name: {{ vol.name }}
+{% endif %}
+{% endif %}
+{% endfor %}
 networks:
   firth_services:
     external: true

--- a/roles/firth_nginx/templates/ssl/aquarionics_ssl.conf
+++ b/roles/firth_nginx/templates/ssl/aquarionics_ssl.conf
@@ -1,0 +1,4 @@
+    ssl_certificate /etc/letsencrypt/live/aquarionics.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/aquarionics.com/privkey.pem;
+    ssl_session_cache    shared:SSL:1m;
+    ssl_session_timeout 10m;


### PR DESCRIPTION
## Summary

- **`additional_volumes` feature**: New field on `firth_laravel_app` role supporting both bind mounts (`src`/`dest`) and named external volumes (`name`/`dest`/`external`); propagated to app service, worker service, and top-level volumes block in the docker-compose template
- **Staging inheritance**: Staging context inherits `additional_volumes` from production unless overridden
- **Thalium provisioning**: Adds thalium to `firth.water.gkhs.net` laravel apps — FrankenPHP/Octane backend, GHCR image, Redis, Elasticsearch config, RPG library bind mount, Elasticsearch certs named volume, staging on thalium.istic.dev
- **aquarionics SSL snippet**: New `roles/firth_nginx/templates/ssl/aquarionics_ssl.conf` for thalium's production domain

## Test Plan

- [ ] Add vault secrets: `vault_thalium_app_key`, `vault_thalium_staging_app_key`, `vault_thalium_redis_password`, `vault_thalium_staging_redis_password`, `vault_thalium_es_user`, `vault_thalium_es_pass`
- [ ] Run: `ansible-playbook firth.yml --tags firth_laravel_app --limit firth.water.gkhs.net --check`
- [ ] Apply: `ansible-playbook firth.yml --tags firth_laravel_app --limit firth.water.gkhs.net`
- [ ] Verify thalium and thalium-staging containers start on firth
- [ ] Verify nginx vhosts respond on thalium.aquarionics.com and thalium.istic.dev
- [ ] Confirm `elasticsearch_certs` external volume resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)