### PR TITLE
Point aquarionics.com nginx vhosts at the dedicated wildcard cert; remove foip.me

### DIFF
--- a/bin/generate-firth-certbot.sh
+++ b/bin/generate-firth-certbot.sh
@@ -61,8 +61,6 @@ echo "Generating certificates for nicholasavenell.com"
 sudo --preserve-env=AWS_PROFILE certbot certonly -n --expand --dns-route53 --cert-name nicholasavenell.com -d "*.nicholasavenell.com" -d "*.nicholasavenell.net" -d nicholasavenell.com -d nicholasavenell.net
 echo "Generating certificates for bromioscreations.com"
 sudo --preserve-env=AWS_PROFILE certbot certonly -n --expand --dns-route53 --cert-name bromioscreations.com -d "*.bromioscreations.com"
-echo "Generating certificates for foip.me"
-sudo --preserve-env=AWS_PROFILE certbot certonly -n --expand --dns-route53 --cert-name foip.me -d "*.foip.me"
 echo "Generating certificates for larp.me"
 sudo --preserve-env=AWS_PROFILE certbot certonly -n --expand --dns-route53 --cert-name larp.me -d "larp.me" -d "*.larp.me" -d "larp.me.uk" -d "*.larp.me.uk"
 echo "Generating certificates for camlarp"

--- a/bin/generate-firth-certbot.sh
+++ b/bin/generate-firth-certbot.sh
@@ -9,17 +9,16 @@ set -o errtrace #Cascade that to all functions
 echo "Generating certificates for firth"
 sudo certbot -n -t certonly --expand --nginx --deploy-hook "service dovecot restart" --cert-name firth.water.gkhs.net \
 	--domains firth.water.gkhs.net -d "istic.net" \
-	-d "stream.aquarionics.com,www.aquarionics.com,aquarionics.com,old.aquarionics.com,plex.aquarionics.com,vis.aquarionics.com,panopticon.aquarionics.com,thalium.aquarionics.com,vtt.aquarionics.com,flix.aquarionics.com,dailyphoto.aquarionics.com,live.dailyphoto.aquarionics.com,feeds.aquarionics.com,wywo.aquarionics.com" \
 	-d "factionfiction.net,www.factionfiction.net" \
-	-d "idlespeculation.foip.me,herodiaries.foip.me,sevenmirrors.foip.me,istic.co" \
 	-d "themonthlymoon.com" \
-	-d "ludo.istic.co,imperial.istic.net,altru.istic.net,log.istic.net,hol.istic.net,live.art.istic.net,imperial.istic.net,material.istic.net" \
+	-d "ludo.istic.co,imperial.istic.net,altru.istic.net,log.istic.net,hol.istic.net,live.art.istic.net,imperial.istic.net,material.istic.net,istic.co" \
 	-d "warehousebasement.com,www.warehousebasement.com" \
 	-d "dagon.church,live.dagon.church,wiki.dagon.church" \
 	-d "mechan.istic.net,optim.istic.net" \
 	-d "www.larpfic.com,larpfic.com,www.lrpfic.com,lrpfic.com" \
 	-d "www.deathuntodarkness.org" \
-	-d "deadbadgerdesigns.co.uk,www.deadbadgerdesigns.co.uk"
+	-d "deadbadgerdesigns.co.uk,www.deadbadgerdesigns.co.uk" \
+	-d "live.dailyphoto.aquarionics.com"
 
 #forums.profounddecisions.co.uk
 # omnyom.com,www.omnyom.com,\

--- a/bin/update-all-certbots.sh
+++ b/bin/update-all-certbots.sh
@@ -4,10 +4,10 @@
 #ssh-add
 
 for host in firth atoll; do
-	echo "Updating autopelago on $host.istic.systems"
-	ssh -A $host.istic.systems "cd code/autopelago/bin/ && git pull" 2>&1 | ts "[$host:%T]"
+	# echo "Updating autopelago on $host.istic.systems"
+	# ssh -A $host.istic.systems "cd code/autopelago/bin/ && git pull" 2>&1 | ts "[$host:%T]"
 	echo "Updating certbot on $host.istic.systems"
-	ssh $host.istic.systems code/autopelago/bin/generate-$host-certbot.sh 2>&1 | ts "[$host:%T]" &
+	cat bin/generate-$host-certbot.sh | ssh -A $host.istic.systems "bash -s" 2>&1 | ts "[$host:%T]" &
 done
 
 wait

--- a/group_vars/all/00-core.yml
+++ b/group_vars/all/00-core.yml
@@ -8,7 +8,7 @@ apt_cache_time: 21600
 
 mysql_host: 127.0.0.1
 
-ansible_python_interpreter: /usr/bin/python3
+# ansible_python_interpreter: /usr/bin/python3
 
 forward_emails_to: aquarion
 

--- a/group_vars/all/30-network.yml
+++ b/group_vars/all/30-network.yml
@@ -3,3 +3,4 @@ firth_ip: 46.4.84.119
 
 loadbalancer_domain: tributary.water.gkhs.net
 loadbalancer_ip: 49.12.23.194
+loadbalancer_ipv6: 2a01:4f8:c011:f6::1

--- a/group_vars/external_hosts/00-core.yml
+++ b/group_vars/external_hosts/00-core.yml
@@ -1,0 +1,1 @@
+ansible_python_interpreter: /usr/bin/python3

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,6 +1,8 @@
 ---
 - name: AWS Roles
-  hosts: all:!localactions
+  hosts: localactions
+  vars:
+    ansible_python_interpreter: "{{ ansible_playbook_python }}"
   handlers:
     - name: Import global handlers
       ansible.builtin.import_tasks: roles/global_things/handlers/main.yml
@@ -8,20 +10,14 @@
     - name: aws_profiles
       role: aws_profiles
       become: false
-      connection: local
       tags: aws
-      run_once: true
     - name: firth_dns
       role: firth_dns
       become: false
-      connection: local
       tags: route53
-      run_once: true
     - role: aws_pdforums
       become: false
-      connection: local
       tags: aws
-      run_once: true
 
 - name: Actions on all hosts
   hosts: all

--- a/roles/firth_dns/tasks/zones/aquarionics.yml
+++ b/roles/firth_dns/tasks/zones/aquarionics.yml
@@ -25,7 +25,7 @@
         aws_profile: aqcom
         type: AAAA
         ttl: "300"
-        value: "{{ ansible_default_ipv6.address }}"
+        value: "{{ loadbalancer_ipv6 }}"
 
     - name: Aquarionics.com. - MX
       amazon.aws.route53:
@@ -275,7 +275,7 @@
         aws_profile: aqcom
         type: AAAA
         ttl: "300"
-        value: "{{ ansible_default_ipv6.address }}"
+        value: "{{ loadbalancer_ipv6 }}"
 
     - name: Tumblr.aquarionics.com. - CNAME
       amazon.aws.route53:
@@ -297,7 +297,7 @@
         aws_profile: aqcom
         type: AAAA
         ttl: "300"
-        value: "{{ ansible_default_ipv6.address }}"
+        value: "{{ loadbalancer_ipv6 }}"
 
     - name: Wiki.aquarionics.com. - CNAME
       amazon.aws.route53:

--- a/roles/firth_dns/tasks/zones/aquarionics_cf.yml
+++ b/roles/firth_dns/tasks/zones/aquarionics_cf.yml
@@ -27,7 +27,7 @@
         api_token: "{{ cloudflare_api_key }}"
         type: AAAA
         # ttl: "300"
-        value: "{{ ansible_default_ipv6.address }}"
+        value: "{{ loadbalancer_ipv6 }}"
 
     - name: (CF) Aquarionics.com. - MX 1/5
       community.general.cloudflare_dns:
@@ -307,7 +307,7 @@
         api_token: "{{ cloudflare_api_key }}"
         type: AAAA
         # ttl: "300" # Don't set ttl on proxied records
-        value: "{{ ansible_default_ipv6.address }}"
+        value: "{{ loadbalancer_ipv6 }}"
         proxied: true
 
     - name: (CF) Tumblr.aquarionics.com. - CNAME

--- a/roles/firth_dns/tasks/zones/bromioscreations.yml
+++ b/roles/firth_dns/tasks/zones/bromioscreations.yml
@@ -19,7 +19,7 @@
     aws_profile: aqcom
     type: AAAA
     ttl: "300"
-    value: "{{ ansible_default_ipv6.address }}"
+    value: "{{ loadbalancer_ipv6 }}"
 
 - name: Bromioscreations.com. - MX
   amazon.aws.route53:

--- a/roles/firth_dns/tasks/zones/foipme.yml
+++ b/roles/firth_dns/tasks/zones/foipme.yml
@@ -1,8 +1,14 @@
 ---
+# We no longer own foip.me - every record below is explicitly deleted
+# (rather than just removing this file) so a real ansible run actually
+# tears down the Route53 records instead of merely stopping future
+# creates. Once this has run successfully against firth, this file and
+# its include in main.yml can be removed entirely.
+
 - name: Foip.me. - A
   amazon.aws.route53:
     overwrite: true
-    command: create
+    command: delete
     zone: foip.me
     record: foip.me.
     aws_profile: aqcom
@@ -13,7 +19,7 @@
 - name: Foip.me. - NS
   amazon.aws.route53:
     overwrite: true
-    command: create
+    command: delete
     zone: foip.me
     record: foip.me.
     aws_profile: aqcom
@@ -36,7 +42,7 @@
 - name: Dud.foip.me. - A
   amazon.aws.route53:
     overwrite: true
-    command: create
+    command: delete
     zone: foip.me
     record: dud.foip.me.
     aws_profile: aqcom
@@ -47,7 +53,7 @@
 - name: Sands.foip.me. - A
   amazon.aws.route53:
     overwrite: true
-    command: create
+    command: delete
     zone: foip.me
     record: sands.foip.me.
     aws_profile: aqcom
@@ -91,7 +97,7 @@
 - name: Forgotten.foip.me. - A
   amazon.aws.route53:
     overwrite: true
-    command: create
+    command: delete
     zone: foip.me
     record: forgotten.foip.me.
     aws_profile: aqcom
@@ -102,7 +108,7 @@
 - name: Ojaqs.foip.me. - A
   amazon.aws.route53:
     overwrite: true
-    command: create
+    command: delete
     zone: foip.me
     record: ojaqs.foip.me.
     aws_profile: aqcom
@@ -113,7 +119,7 @@
 - name: Bless.ojaqs.foip.me. - A
   amazon.aws.route53:
     overwrite: true
-    command: create
+    command: delete
     zone: foip.me
     record: bless.ojaqs.foip.me.
     aws_profile: aqcom
@@ -124,7 +130,7 @@
 - name: Diaspora.foip.me. - A
   amazon.aws.route53:
     overwrite: true
-    command: create
+    command: delete
     zone: foip.me
     record: diaspora.foip.me.
     aws_profile: aqcom
@@ -135,7 +141,7 @@
 - name: Herodiaries.foip.me. - A
   amazon.aws.route53:
     overwrite: true
-    command: create
+    command: delete
     zone: foip.me
     record: herodiaries.foip.me.
     aws_profile: aqcom
@@ -146,7 +152,7 @@
 - name: Sevenmirrors.foip.me. - A
   amazon.aws.route53:
     overwrite: true
-    command: create
+    command: delete
     zone: foip.me
     record: sevenmirrors.foip.me.
     aws_profile: aqcom
@@ -157,7 +163,7 @@
 - name: Idlespeculation.foip.me. - A
   amazon.aws.route53:
     overwrite: true
-    command: create
+    command: delete
     zone: foip.me
     record: idlespeculation.foip.me.
     aws_profile: aqcom
@@ -168,7 +174,7 @@
 - name: Bobbitworm.foip.me. - A
   amazon.aws.route53:
     overwrite: true
-    command: create
+    command: delete
     zone: foip.me
     record: bobbitworm.foip.me.
     aws_profile: aqcom

--- a/roles/firth_dns/tasks/zones/nicholasavenell.yml
+++ b/roles/firth_dns/tasks/zones/nicholasavenell.yml
@@ -19,7 +19,7 @@
     aws_profile: aqcom
     type: AAAA
     ttl: "300"
-    value: "{{ ansible_default_ipv6.address }}"
+    value: "{{ loadbalancer_ipv6 }}"
 
 - name: Www.nicholasavenell.com. - A
   amazon.aws.route53:
@@ -54,7 +54,7 @@
     aws_profile: aqcom
     type: AAAA
     ttl: "300"
-    value: "{{ ansible_default_ipv6.address }}"
+    value: "{{ loadbalancer_ipv6 }}"
 
 - name: Www.nicholasavenell.net. - A
   amazon.aws.route53:

--- a/roles/firth_nginx/templates/ssl/foipme_ssl.conf
+++ b/roles/firth_nginx/templates/ssl/foipme_ssl.conf
@@ -1,5 +1,0 @@
-
-    ssl_certificate /etc/letsencrypt/live/foip.me/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/foip.me/privkey.pem;
-    ssl_session_cache    shared:SSL:1m;
-    ssl_session_timeout 10m;

--- a/roles/firth_nginx/templates/vhosts/aquarionics
+++ b/roles/firth_nginx/templates/vhosts/aquarionics
@@ -54,7 +54,28 @@ server {
 server {
   listen 443 ssl proxy_protocol;
   listen [::]:443 ssl proxy_protocol;
-  server_name wywo.aquarionics.com www.aquarionics.com factionfiction.net blogs.water.gkhs.net *.blogs.water.gkhs.net omnyom.com www.cleartextcontent.co.uk herodiaries.foip.me themonthlymoon.com idlespeculation.foip.me;
+  server_name wywo.aquarionics.com www.aquarionics.com;
+  add_header X-WhyAmI wordpress;
+  add_header Access-Control-Allow-Origin: https://*.aquarionics.com/;
+  include /etc/nginx/snippets/ssl/aquarionics_ssl.conf;
+
+  error_log /var/log/nginx/wordpress.error.log;
+  access_log /var/log/nginx/wordpress.access.log;
+
+  location / {
+    proxy_pass http://container-wordpress;
+    proxy_set_header Host $http_host;
+    proxy_set_header X-Forwarded-For $remote_addr;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+  include /etc/nginx/snippets/errors.conf;
+  client_max_body_size 32M;
+}
+
+server {
+  listen 443 ssl proxy_protocol;
+  listen [::]:443 ssl proxy_protocol;
+  server_name factionfiction.net blogs.water.gkhs.net *.blogs.water.gkhs.net omnyom.com www.cleartextcontent.co.uk herodiaries.foip.me themonthlymoon.com idlespeculation.foip.me;
   add_header X-WhyAmI wordpress;
   add_header Access-Control-Allow-Origin: https://*.aquarionics.com/;
   include /etc/nginx/snippets/ssl/letsencrypt_ssl.conf;
@@ -105,7 +126,7 @@ server {
   listen [::]:443 ssl proxy_protocol;
   root /var/www/;
   include /etc/nginx/snippets/errors.conf;
-  include /etc/nginx/snippets/ssl/letsencrypt_ssl.conf;
+  include /etc/nginx/snippets/ssl/aquarionics_ssl.conf;
   add_header X-WhyAmI "feeds redirect";
   return 301 https://www.aquarionics.com/feed/;
 }

--- a/roles/firth_nginx/templates/vhosts/aquarionics
+++ b/roles/firth_nginx/templates/vhosts/aquarionics
@@ -4,14 +4,6 @@ upstream container-wordpress {
 }
 
 server {
-  listen 443 ssl proxy_protocol;
-  listen 80;
-  server_name herodiaries.blogs.water.gkhs.net;
-  return 301 $scheme://herodiaries.foip.me;
-  add_header X-WhyAmI "wordpress heroediaries redirect";
-}
-
-server {
   listen 80;
   listen [::]:80;
   server_name
@@ -22,9 +14,7 @@ server {
   blogs.water.gkhs.net *.blogs.water.gkhs.net
   omnyom.com
   www.cleartextcontent.co.uk
-  herodiaries.foip.me
   themonthlymoon.com
-  idlespeculation.foip.me
   blogs.istic.network *.blogs.istic.network;
   return 301 https://$host$request_uri;
   include /etc/nginx/snippets/errors.conf;
@@ -75,7 +65,7 @@ server {
 server {
   listen 443 ssl proxy_protocol;
   listen [::]:443 ssl proxy_protocol;
-  server_name factionfiction.net blogs.water.gkhs.net *.blogs.water.gkhs.net omnyom.com www.cleartextcontent.co.uk herodiaries.foip.me themonthlymoon.com idlespeculation.foip.me;
+  server_name factionfiction.net blogs.water.gkhs.net *.blogs.water.gkhs.net omnyom.com www.cleartextcontent.co.uk themonthlymoon.com;
   add_header X-WhyAmI wordpress;
   add_header Access-Control-Allow-Origin: https://*.aquarionics.com/;
   include /etc/nginx/snippets/ssl/letsencrypt_ssl.conf;

--- a/roles/firth_nginx/templates/vhosts/foundryvtt
+++ b/roles/firth_nginx/templates/vhosts/foundryvtt
@@ -15,7 +15,7 @@ server {
     client_max_body_size 300M;
 
     add_header X-WhyAmI FoundryVTT;
-    include /etc/nginx/snippets/ssl/letsencrypt_ssl.conf;
+    include /etc/nginx/snippets/ssl/aquarionics_ssl.conf;
 
     # Proxy Requests to Foundry VTT
     location / {

--- a/roles/firth_nginx/templates/vhosts/gone
+++ b/roles/firth_nginx/templates/vhosts/gone
@@ -14,17 +14,6 @@ server {
     listen 80;
     listen [::]:80;
     server_name
-    bless.ojaqs.foip.me sands.foip.me sevenmirrors.foip.me
-    ;
-    include /etc/nginx/snippets/errors.conf;
-    add_header X-WhyAmI gone;
-    return 410;
-}
-
-server {
-    listen 80;
-    listen [::]:80;
-    server_name
     ark.ludo.istic.net atoll.istic.net errorz.istic.net feathers.casu.istic.net hol.istic.net kabbal.istic.net kick.istic.net log.istic.net mc.ludo.istic.net mimir.cabal.istic.net odyshirt.istic.net pd.casu.istic.net wildfeathers.casu.istic.net;
     include /etc/nginx/snippets/errors.conf;
     add_header X-WhyAmI "istic gone";
@@ -41,20 +30,6 @@ server {
 
     include /etc/nginx/snippets/ssl/letsencrypt_ssl.conf;
     add_header X-WhyAmI "larpme gone";
-
-    include /etc/nginx/snippets/errors.conf;
-    return 410;
-}
-
-server {
-    listen 443 ssl proxy_protocol;
-    listen [::]:443 ssl proxy_protocol;
-    server_name
-    bless.ojaqs.foip.me sands.foip.me sevenmirrors.foip.me
-    ;
-
-    add_header X-WhyAmI "foipme gone";
-    include /etc/nginx/snippets/ssl/foipme_ssl.conf;
 
     include /etc/nginx/snippets/errors.conf;
     return 410;

--- a/roles/firth_nginx/templates/vhosts/jellyfin
+++ b/roles/firth_nginx/templates/vhosts/jellyfin
@@ -32,7 +32,7 @@ server {
     #ssl_stapling_verify on;
 
     add_header X-WhyAmI jellyfin;
-    include /etc/nginx/snippets/ssl/letsencrypt_ssl.conf;
+    include /etc/nginx/snippets/ssl/aquarionics_ssl.conf;
 
     # Security / XSS Mitigation Headers
     # NOTE: X-Frame-Options may cause issues with the webOS app

--- a/roles/firth_nginx/templates/vhosts/miscweb
+++ b/roles/firth_nginx/templates/vhosts/miscweb
@@ -64,12 +64,28 @@ server {
   warehousebasement.com
   dagon.church live.dagon.church wiki.dagon.church
   istic.co
-  old.aquarionics.com panopticon.aquarionics.com wiki.aquarionics.com
-  live.dailyphoto.aquarionics.com dailyphoto.aquarionics.com
+  live.dailyphoto.aquarionics.com
   www.deathuntodarkness.org
   deadbadgerdesigns.co.uk www.deadbadgerdesigns.co.uk;
   include /etc/nginx/snippets/ssl/letsencrypt_ssl.conf;
 
+
+  error_log /var/log/nginx/miscweb.error.log;
+  access_log /var/log/nginx/miscweb.access.log;
+  add_header X-WhyAmI miscweb;
+
+  location / {
+    proxy_pass http://docker-miscweb;
+    include /etc/nginx/snippets/proxy_params.nginx.conf;
+  }
+  include /etc/nginx/snippets/errors.conf;
+}
+
+server {
+  listen 443 ssl proxy_protocol;
+  listen [::]:443 ssl proxy_protocol;
+  server_name old.aquarionics.com panopticon.aquarionics.com wiki.aquarionics.com dailyphoto.aquarionics.com;
+  include /etc/nginx/snippets/ssl/aquarionics_ssl.conf;
 
   error_log /var/log/nginx/miscweb.error.log;
   access_log /var/log/nginx/miscweb.access.log;

--- a/roles/firth_nginx/templates/vhosts/miscweb
+++ b/roles/firth_nginx/templates/vhosts/miscweb
@@ -21,7 +21,6 @@ server {
   www.deathuntodarkness.org
   *.istic.net
   *.istic.dev
-  *.foip.me
   *.bromioscreations.com
   *.aquarionics.com
   *.hubris.house
@@ -176,26 +175,6 @@ server {
   server_name *.hubris.house hubris.house;
   include /etc/nginx/snippets/ssl/hubris_ssl.conf;
   add_header X-WhyAmI "miscweb hubris";
-
-  location / {
-    proxy_pass http://docker-miscweb;
-    include /etc/nginx/snippets/proxy_params.nginx.conf;
-  }
-  include /etc/nginx/snippets/errors.conf;
-}
-
-#  ___    _        __  __
-# | __|__(_)_ __  |  \/  |___
-# | _/ _ \ | '_ \_| |\/| / -_)
-# |_|\___/_| .__(_)_|  |_\___|
-#          |_|
-
-server {
-  listen 443 ssl proxy_protocol;
-  listen [::]:443 ssl proxy_protocol;
-  server_name *.foip.me;
-  include /etc/nginx/snippets/ssl/foipme_ssl.conf;
-  add_header X-WhyAmI "miscweb foipme";
 
   location / {
     proxy_pass http://docker-miscweb;

--- a/roles/firth_nginx/templates/vhosts/streamsite
+++ b/roles/firth_nginx/templates/vhosts/streamsite
@@ -21,7 +21,7 @@ server {
     root {{ media_library }};
 
 	include /etc/nginx/snippets/errors.conf;
-    include /etc/nginx/snippets/ssl/letsencrypt_ssl.conf;
+    include /etc/nginx/snippets/ssl/aquarionics_ssl.conf;
 
   add_header X-WhyAmI vis;
 


### PR DESCRIPTION
## Summary
- The general firth letsencrypt cert no longer carries aquarionics.com in its SANs, so aquarionics.com vhosts need to use the dedicated `aquarionics.com,*.aquarionics.com` wildcard cert instead.
- Split the mixed server blocks in `aquarionics` and `miscweb` vhosts so aquarionics.com domains move to `aquarionics_ssl.conf` while unrelated domains (factionfiction.net, istic.net, foip.me, etc.) stay on `letsencrypt_ssl.conf`.
- `live.dailyphoto.aquarionics.com` is a two-level subdomain not covered by the `*.aquarionics.com` wildcard, so it stays on the general cert — re-added as its own `-d` entry in `generate-firth-certbot.sh`.
- We no longer own foip.me, so all support for it is removed: the dedicated `foipme_ssl.conf` cert snippet, the certbot generation line, and every nginx vhost reference (redirects, server_name lists, "gone" 410 blocks). The Route53 zone task (`zones/foipme.yml`) is **not** deleted outright — every record's `command` was flipped from `create` to `delete` so a real ansible run actually tears down the existing records; the file and its include can be removed once that run has succeeded.

## Test plan
- [ ] `nginx -t` on firth after deploy to confirm config is valid
- [ ] Verify TLS handshake/cert served for `www.aquarionics.com`, `wywo.aquarionics.com`, `feeds.aquarionics.com`, `flix.aquarionics.com`, `vtt.aquarionics.com`, `old.aquarionics.com`, `panopticon.aquarionics.com`, `wiki.aquarionics.com`, `dailyphoto.aquarionics.com` now uses the aquarionics wildcard cert
- [ ] Verify `live.dailyphoto.aquarionics.com` still gets a valid cert from the general firth cert after re-running certbot
- [ ] Verify unrelated domains in the split blocks (factionfiction.net, istic.co, dagon.church, etc.) are unaffected
- [ ] Run the `firth_dns` role and confirm all foip.me Route53 records are deleted, then remove `zones/foipme.yml` and its include in a follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)