### PR TITLE
Fix localhost and SQLite bind-mount issues in playbook

### DIFF
--- a/host_vars/firth.water.gkhs.net/laravel_apps.yml
+++ b/host_vars/firth.water.gkhs.net/laravel_apps.yml
@@ -95,6 +95,9 @@ firth_laravel_app_apps:
       password: "{{ laravel_apps_mail_password }}"
       from_address: "{{ laravel_apps_mail_from_address }}"
       from_name: "Novelathon Support"
+    additional_volumes:
+      - src: /home/docker/novelathon/storage/app
+        dest: /var/www/html/storage/app
     staging:
       image_tag: staging
       port: 9002
@@ -109,6 +112,9 @@ firth_laravel_app_apps:
       redis:
         username: "{{ firth_novelathon_staging_redis_username }}"
         password: "{{ firth_novelathon_staging_redis_password }}"
+      additional_volumes:
+        - src: /home/docker/novelathon-staging/storage/app
+          dest: /var/www/html/storage/app
 
   - name: bloom
     image: ghcr.io/aquarion/bloom
@@ -242,12 +248,13 @@ firth_laravel_app_apps:
     additional_env:
       APP_VENUE_SHEET_ID: "1p2CS7rxPWyMs7g4OHH287j6iIPGkZb3VA7VRLBr0okA"
       GOOGLE_CREDENTIALS_PATH: google/credentials.json
+      DB_DATABASE: /var/www/html/storage/database/production.sqlite
     additional_files:
       - src: files/laravel/wereabouts/google_credentials.vault.json
         dest: google/credentials.json
     additional_volumes:
-      - src: /home/docker/wereabouts/database.sqlite
-        dest: /var/www/html/database/database.sqlite
+      - src: /home/docker/wereabouts/storage/database
+        dest: /var/www/html/storage/database
     staging:
       image_tag: staging
       port: 9006
@@ -261,12 +268,13 @@ firth_laravel_app_apps:
       additional_env:
         APP_VENUE_SHEET_ID: "1p2CS7rxPWyMs7g4OHH287j6iIPGkZb3VA7VRLBr0okA"
         GOOGLE_CREDENTIALS_PATH: google/credentials.json
+        DB_DATABASE: /var/www/html/storage/database/staging.sqlite
       additional_files:
         - src: files/laravel/wereabouts/google_credentials.vault.json
           dest: google/credentials.json
       additional_volumes:
-        - src: /home/docker/wereabouts-staging/database.sqlite
-          dest: /var/www/html/database/database.sqlite
+        - src: /home/docker/wereabouts-staging/storage/database
+          dest: /var/www/html/storage/database
 
   # Vault variables required (add to vault manually):
   #   vault_thalium_app_key
@@ -303,14 +311,15 @@ firth_laravel_app_apps:
     additional_env:
       DOCKER_PDF_LIBRARY: /mnt/rpg
       LIBRARY_URL: https://thalium.aquarionics.com/_libris/
+      DB_DATABASE: /var/www/html/storage/database/production.sqlite
     additional_volumes:
       - src: /home/library/RPG/Systems
         dest: /mnt/rpg
       - name: elasticsearch_certs
         dest: /usr/share/elasticsearch/config/certs
         external: true
-      - src: /home/docker/thalium/database.sqlite
-        dest: /var/www/html/database/database.sqlite
+      - src: /home/docker/thalium/storage/database
+        dest: /var/www/html/storage/database
     staging:
       image_tag: staging
       port: 8003
@@ -324,11 +333,12 @@ firth_laravel_app_apps:
       additional_env:
         DOCKER_PDF_LIBRARY: /mnt/rpg
         LIBRARY_URL: https://thalium.istic.dev/_libris/
+        DB_DATABASE: /var/www/html/storage/database/staging.sqlite
       additional_volumes:
         - src: /home/library/RPG/Systems
           dest: /mnt/rpg
         - name: elasticsearch_certs
           dest: /usr/share/elasticsearch/config/certs
           external: true
-        - src: /home/docker/thalium-staging/database.sqlite
-          dest: /var/www/html/database/database.sqlite
+        - src: /home/docker/thalium-staging/storage/database
+          dest: /var/www/html/storage/database

--- a/roles/firth_laravel_app/tasks/app.yml
+++ b/roles/firth_laravel_app/tasks/app.yml
@@ -28,6 +28,7 @@
       additional_volumes: "{{ firth_laravel_app_item.additional_volumes | default([]) }}"
       nginx_snippet: "{{ firth_laravel_app_item.nginx_snippet | default('') }}"
       system_user: "{{ firth_laravel_app_item.name }}"
+      container_uid: "{{ firth_laravel_app_item.container_uid | default('82') }}"
   tags: [always, firth_laravel_app, firth_laravel_app_install]
 
 - name: Reset files changed state for {{ firth_laravel_app_item.name }} # noqa: var-naming[no-role-prefix]

--- a/roles/firth_laravel_app/tasks/deploy.yml
+++ b/roles/firth_laravel_app/tasks/deploy.yml
@@ -19,6 +19,24 @@
         loop_var: vol
       when: fla_ctx.additional_volumes | length > 0
 
+    - name: Ensure host bind-mount directories exist for {{ fla_ctx.name }}
+      ansible.builtin.file:
+        path: "{{ vol.src }}"
+        state: directory
+        owner: "{{ fla_ctx.container_uid | default('82') }}"
+        group: "{{ fla_ctx.system_user }}"
+        mode: "0750"
+      loop: "{{ fla_ctx.additional_volumes | selectattr('src', 'defined') | list }}"
+      loop_control:
+        loop_var: vol
+      when: fla_ctx.additional_volumes | selectattr('src', 'defined') | list | length > 0
+      register: firth_laravel_app_bind_mount_dirs
+
+    - name: Force container recreation if bind-mount directories were created for {{ fla_ctx.name }}
+      ansible.builtin.set_fact:
+        firth_laravel_app_files_changed: true
+      when: firth_laravel_app_bind_mount_dirs.changed | default(false)
+
     - name: Template docker-compose.yml for {{ fla_ctx.name }}
       ansible.builtin.template:
         src: docker-compose.yml.j2

--- a/roles/firth_laravel_app/tasks/staging.yml
+++ b/roles/firth_laravel_app/tasks/staging.yml
@@ -57,6 +57,7 @@
       additional_volumes: "{{ fla.staging.additional_volumes | default(fla.additional_volumes | default([])) }}"
       nginx_snippet: "{{ fla.staging.nginx_snippet | default(fla.nginx_snippet | default('')) }}"
       system_user: "{{ fla.name }}"
+      container_uid: "{{ fla.container_uid | default('82') }}"
   tags: [firth_laravel_app, firth_laravel_app_install]
 
 - name: Provision staging database for {{ fla.name }}

--- a/roles/water_gkhs_common/tasks/main.yml
+++ b/roles/water_gkhs_common/tasks/main.yml
@@ -50,6 +50,7 @@
       - restricted
       - universe
     signed_by: "{{ ubuntu_mirror_key | default('/usr/share/keyrings/ubuntu-archive-keyring.gpg') }}"
+    install_python_debian: true
   tags:
     - certbot
     - ubuntu_sources
@@ -68,6 +69,7 @@
       - restricted
       - universe
     signed_by: "{{ ubuntu_mirror_key | default('/usr/share/keyrings/ubuntu-archive-keyring.gpg') }}"
+    install_python_debian: true
   tags:
     - certbot
     - ubuntu_sources
@@ -224,7 +226,7 @@
 
 - name: Determine remote Python version.
   ansible.builtin.set_fact:
-    water_gkhs_common_python_version: "{% if 'python3' in ansible_python_interpreter | default('') %}python3{% else %}python{% endif %}"
+    water_gkhs_common_python_version: "{% if ansible_python_version.split('.')[0] | int >= 3 %}python3{% else %}python{% endif %}"
   tags: aws
 
 - name: Ensure Python libraries that ansible needs are installed.
@@ -232,7 +234,6 @@
     state: present
     pkg:
       - "{{ water_gkhs_common_python_version }}-boto3"
-      - "{{ water_gkhs_common_python_version }}-boto"
       - "{{ water_gkhs_common_python_version }}-passlib"
   tags:
     - aws
@@ -243,6 +244,8 @@
     state: present
     dest: /etc/sysctl.conf
     regexp: ^fs.inotify.max_user_watches
+    create: true
+    mode: "0644"
   notify: Kick sysctl
   tags: sysctl
 


### PR DESCRIPTION
## Summary

- **water_gkhs_common**: Fix localhost (WSL2) compatibility — add `install_python_debian: true` to deb822_repository tasks; fix Python version detection to use `ansible_python_version` integer comparison; remove `python3-boto` (dropped in Ubuntu 24.04+); add `mode: "0644"` and `create: true` to sysctl.conf lineinfile (WSL2 has no `/etc/sysctl.conf`)
- **firth_laravel_app/deploy.yml**: Switch SQLite handling from file bind-mounts to directory bind-mounts (`storage/database/`). Docker creates a directory when the host path doesn't exist — mounting a directory lets SQLite create journal/WAL files freely and avoids the CANTOPEN error. Directories are owned by `container_uid` (default `82` for Alpine `www-data`) + `system_user` group at mode `0750`
- **firth_laravel_app/app.yml + staging.yml**: Thread `container_uid` through `fla_ctx` so the deploy task can use it for bind-mount directory ownership
- **laravel_apps (wereabouts, thalium, novelathon)**: Update to directory-based volume mounts for `storage/database` (SQLite) and `storage/app` (uploads); add `DB_DATABASE` env vars pointing to named sqlite files within those dirs

## Data migration note

Before running the playbook on firth, manually copy existing SQLite data:
```
cp /home/docker/thalium/database.sqlite /home/docker/thalium/storage/database/production.sqlite
cp /home/docker/wereabouts/database.sqlite /home/docker/wereabouts/storage/database/production.sqlite
```

## Test plan
- [ ] Run playbook locally against localhost (water_gkhs_common tasks pass cleanly on WSL2)
- [ ] Verify wereabouts-staging starts without SQLite CANTOPEN error
- [ ] Verify thalium-staging starts cleanly
- [ ] Copy prod SQLite data to new paths before full prod run

🤖 Generated with [Claude Code](https://claude.com/claude-code)