### PR TITLE
Add scheduler container support to firth_laravel_app

### DIFF
--- a/host_vars/firth.water.gkhs.net/laravel_apps.yml
+++ b/host_vars/firth.water.gkhs.net/laravel_apps.yml
@@ -36,6 +36,9 @@ firth_laravel_app_apps:
   #     from_name: "Example Support"
   #  additional_env: # optional additional environment variables to pass to the container, can be used for things like third-party API keys
   #    EXAMPLE_API_KEY: "{{ vault_example_api_key }}"
+  #  scheduler: true # optional - runs `php artisan schedule:work` in its own container for apps using Laravel's task scheduler
+  #  worker: true # optional - runs a queue worker in its own container
+  #  worker_command: horizon # optional - defaults to "queue:work"
   #  staging: # optional staging config, if you want a separate staging environment with a different image tag and environment variables
   #      ## This is a duplicate of the config above, but with overrides for staging.
   #      ## The staging image should be built and pushed to GHCR by your CI pipeline when you push to your staging branch.
@@ -130,6 +133,7 @@ firth_laravel_app_apps:
     github_deploy_token: "{{ laravel_apps_deploy_token_aquarion }}"
     ghcr_username: "{{ ghcr_username }}"
     ghcr_token: "{{ ghcr_token }}"
+    scheduler: true
     mysql:
       db_name: bloom
       db_user: bloom

--- a/roles/firth_laravel_app/tasks/app.yml
+++ b/roles/firth_laravel_app/tasks/app.yml
@@ -18,6 +18,7 @@
       www_redirect: "{{ firth_laravel_app_item.www_redirect | default(false) }}"
       worker: "{{ firth_laravel_app_item.worker | default(false) }}"
       worker_command: "{{ firth_laravel_app_item.worker_command | default('queue:work') }}"
+      scheduler: "{{ firth_laravel_app_item.scheduler | default(false) }}"
       workdir: "{{ firth_laravel_app_item.workdir | default('/var/www/html') }}"
       mysql: "{{ firth_laravel_app_item.mysql | default({}) }}"
       redis: "{{ firth_laravel_app_item.redis | default({}) }}"

--- a/roles/firth_laravel_app/tasks/staging.yml
+++ b/roles/firth_laravel_app/tasks/staging.yml
@@ -47,6 +47,7 @@
       www_redirect: "{{ fla.staging.www_redirect | default(false) }}"
       worker: "{{ fla.staging.worker | default(fla.worker | default(false)) }}"
       worker_command: "{{ fla.staging.worker_command | default(fla.worker_command | default('queue:work')) }}"
+      scheduler: "{{ fla.staging.scheduler | default(fla.scheduler | default(false)) }}"
       workdir: "{{ fla.staging.workdir | default(fla.workdir | default('/var/www/html')) }}"
       mysql: "{{ fla.staging.mysql | default({}) }}"
       redis: "{{ fla.staging.redis | default({}) }}"

--- a/roles/firth_laravel_app/templates/docker-compose.yml.j2
+++ b/roles/firth_laravel_app/templates/docker-compose.yml.j2
@@ -1,12 +1,5 @@
 # {{ ansible_managed }}
-name: {{ fla_ctx.name }}
-services:
-  app:
-    image: "{{ fla_ctx.image }}:{{ fla_ctx.image_tag }}"
-    restart: unless-stopped
-    ports:
-      - "127.0.0.1:{{ fla_ctx.port }}:{% if fla_ctx.backend == 'fpm' %}9000{% else %}8000{% endif %}"
-    environment: &app-env
+{% macro app_environment() %}
       APP_NAME: "{{ fla_ctx.app_name }}"
       APP_ENV: "{{ fla_ctx.app_env }}"
       APP_KEY: "{{ fla_ctx.app_key }}"
@@ -54,7 +47,8 @@ services:
       {{ key }}: "{{ value }}"
 {% endfor %}
 {% endif %}
-    volumes:
+{%- endmacro %}
+{% macro app_volumes() %}
       - storage:{{ fla_ctx.workdir }}/storage
 {% for file in fla_ctx.additional_files %}
       - {{ docker_root }}/{{ fla_ctx.name }}/secrets/{{ file.dest }}:{{ fla_ctx.workdir }}/storage/app/{{ file.dest }}:ro
@@ -66,6 +60,18 @@ services:
       - {{ vol.name }}:{{ vol.dest }}
 {% endif %}
 {% endfor %}
+{%- endmacro %}
+name: {{ fla_ctx.name }}
+services:
+  app:
+    image: "{{ fla_ctx.image }}:{{ fla_ctx.image_tag }}"
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:{{ fla_ctx.port }}:{% if fla_ctx.backend == 'fpm' %}9000{% else %}8000{% endif %}"
+    environment:
+{{ app_environment() }}
+    volumes:
+{{ app_volumes() }}
     extra_hosts:
       - "host.docker.internal:host-gateway"
     networks:
@@ -80,25 +86,29 @@ services:
     image: "{{ fla_ctx.image }}:{{ fla_ctx.image_tag }}"
     restart: unless-stopped
     command: ["php", "artisan", "{{ fla_ctx.worker_command }}"]
-    environment: &app-env
-      APP_NAME: "{{ fla_ctx.app_name }}"
-      APP_ENV: "{{ fla_ctx.app_env }}"
-      APP_KEY: "{{ fla_ctx.app_key }}"
-      APP_DEBUG: "{{ fla_ctx.app_debug }}"
-      APP_URL: "{{ fla_ctx.app_url }}"
-      LOG_STACK: "stderr,single"
+    environment:
+{{ app_environment() }}
     volumes:
-      - storage:{{ fla_ctx.workdir }}/storage
-{% for file in fla_ctx.additional_files %}
-      - {{ docker_root }}/{{ fla_ctx.name }}/secrets/{{ file.dest }}:{{ fla_ctx.workdir }}/storage/app/{{ file.dest }}:ro
-{% endfor %}
-{% for vol in fla_ctx.additional_volumes %}
-{% if vol.src is defined %}
-      - {{ vol.src }}:{{ vol.dest }}
-{% else %}
-      - {{ vol.name }}:{{ vol.dest }}
+{{ app_volumes() }}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    networks:
+      - firth_services
+    logging:
+      driver: journald
+      options:
+        tag: "$${.Name}/$${.ID}"
+
 {% endif %}
-{% endfor %}
+{% if fla_ctx.scheduler %}
+  scheduler:
+    image: "{{ fla_ctx.image }}:{{ fla_ctx.image_tag }}"
+    restart: unless-stopped
+    command: ["php", "artisan", "schedule:work"]
+    environment:
+{{ app_environment() }}
+    volumes:
+{{ app_volumes() }}
     extra_hosts:
       - "host.docker.internal:host-gateway"
     networks:


### PR DESCRIPTION
## Summary
- Adds a `scheduler: true` option to the `firth_laravel_app` role, mirroring the existing `worker: true` pattern — runs `php artisan schedule:work` in its own container. This is the first Laravel task-scheduler support in this role.
- Enabled for `bloom` (production + staging, inherited via the existing staging-defaults-to-prod pattern) ahead of its upcoming "tombstones" feature (aquarion/bloom#157), which will be the project's first use of Laravel's scheduler.
- **Bug fix found along the way:** the `worker` block's `environment: &app-env` re-declares the same YAML anchor name used by `app`'s block, which looks like inheritance but isn't — duplicate anchor names each independently define their own value, and there's no `<<: *app-env` merge key anywhere in the file. Verified empirically (see test plan) that `worker` was silently missing `DB_CONNECTION`/`REDIS_*`/`MAIL_*` entirely.
- Factored the shared `environment:`/`volumes:` blocks into two Jinja2 macros (`app_environment()`, `app_volumes()`) so `app`/`worker`/`scheduler` share one source of truth and can't drift apart again. Dropped the anchor since it was never functioning as one.

## Test plan
- [x] Rendered the template locally with `jinja2` + `yaml.safe_load` against a mock `bloom`-shaped context (worker off/on, scheduler on) — confirmed valid YAML output and that `worker`/`scheduler` now carry the full `DB_*`/`REDIS_*`/`MAIL_*` env set that `app` has.
- [x] `poetry run ansible-lint roles/firth_laravel_app/ host_vars/firth.water.gkhs.net/laravel_apps.yml` — clean.
- [x] `poetry run pre-commit run` on all changed files — clean.
- [ ] Apply to the `firth.water.gkhs.net` host and confirm the `bloom-scheduler`/`bloom-staging-scheduler` containers come up and `docker logs` shows `schedule:work` running (harmless no-op until bloom's tombstones feature actually registers scheduled commands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)