### PR TITLE
Fix Thalium nginx snippet being clobbered by staging deploy

### DIFF
--- a/roles/firth_laravel_app/tasks/nginx.yml
+++ b/roles/firth_laravel_app/tasks/nginx.yml
@@ -12,7 +12,7 @@
 - name: Deploy nginx snippet for {{ fla_ctx.name }}
   ansible.builtin.template:
     src: "vhosts/snippets/{{ fla_ctx.nginx_snippet }}.conf.j2"
-    dest: "/etc/nginx/snippets/apps/{{ fla_ctx.nginx_snippet }}.conf"
+    dest: "/etc/nginx/snippets/apps/{{ fla_ctx.name }}.conf"
     owner: root
     group: root
     mode: "0644"

--- a/roles/firth_laravel_app/templates/vhosts/app.conf.j2
+++ b/roles/firth_laravel_app/templates/vhosts/app.conf.j2
@@ -38,7 +38,7 @@ server {
     }
 
 {% if fla_ctx.nginx_snippet %}
-    include /etc/nginx/snippets/apps/{{ fla_ctx.nginx_snippet }}.conf;
+    include /etc/nginx/snippets/apps/{{ fla_ctx.name }}.conf;
 {% endif %}
 
     location / {


### PR DESCRIPTION
## Summary
- The Thalium app nginx snippet (`/etc/nginx/snippets/apps/thalium.conf`) was rendered to a destination path keyed only by `nginx_snippet` ("thalium"), shared by both the prod and staging deploy contexts. Every Ansible run deployed prod first, then staging immediately overwrote the same file.
- As a result, production's `_authcheck` (`auth_request`) target and `_thumbnails` alias were silently pointed at the staging app instead of prod. Since staging uses a different `APP_KEY` and Redis session store, prod could never validate a session cookie via the authcheck, breaking cookie auth on `https://thalium.aquarionics.com/_libris/...`.
- Namespaces the rendered snippet by `fla_ctx.name` (`thalium.conf` vs `thalium-staging.conf`) so each context gets its own file with correct values, and updates the vhost template's `include` to match.

## Test plan
- [ ] Run the `firth_laravel_app` role against `firth.water.gkhs.net` (tags `firth_laravel_app`)
- [ ] Confirm `/etc/nginx/snippets/apps/thalium.conf` and `thalium-staging.conf` both exist with correct per-site `_authcheck` proxy_pass and `_thumbnails` alias
- [ ] Verify `nginx -t` passes and reload succeeds
- [ ] Confirm a logged-in prod cookie can fetch a `/_libris/...` asset on `https://thalium.aquarionics.com`