### PR TITLE
Fix bind-mount permission clobbering for shared media library

### DIFF
--- a/host_vars/firth.water.gkhs.net/laravel_apps.yml
+++ b/host_vars/firth.water.gkhs.net/laravel_apps.yml
@@ -36,6 +36,10 @@ firth_laravel_app_apps:
   #     from_name: "Example Support"
   #  additional_env: # optional additional environment variables to pass to the container, can be used for things like third-party API keys
   #    EXAMPLE_API_KEY: "{{ vault_example_api_key }}"
+  #  additional_volumes: # optional extra bind mounts/named volumes for the container
+  #    - src: /home/docker/example/storage/app # bind mount from the host
+  #      dest: /var/www/html/storage/app
+  #      manage_owner: false # optional, defaults to true - set false for pre-existing/shared paths (e.g. a media library) so the role doesn't overwrite their ownership/mode every deploy
   #  staging: # optional staging config, if you want a separate staging environment with a different image tag and environment variables
   #      ## This is a duplicate of the config above, but with overrides for staging.
   #      ## The staging image should be built and pushed to GHCR by your CI pipeline when you push to your staging branch.
@@ -315,6 +319,7 @@ firth_laravel_app_apps:
     additional_volumes:
       - src: /home/library/RPG/Systems
         dest: /mnt/rpg
+        manage_owner: false # shared media library, not thalium-owned - don't clobber its existing ownership/mode
       - name: elasticsearch_certs
         dest: /usr/share/elasticsearch/config/certs
         external: true
@@ -337,6 +342,7 @@ firth_laravel_app_apps:
       additional_volumes:
         - src: /home/library/RPG/Systems
           dest: /mnt/rpg
+          manage_owner: false # shared media library, not thalium-owned - don't clobber its existing ownership/mode
         - name: elasticsearch_certs
           dest: /usr/share/elasticsearch/config/certs
           external: true

--- a/roles/firth_laravel_app/tasks/deploy.yml
+++ b/roles/firth_laravel_app/tasks/deploy.yml
@@ -23,9 +23,9 @@
       ansible.builtin.file:
         path: "{{ vol.src }}"
         state: directory
-        owner: "{{ fla_ctx.container_uid | default('82') }}"
-        group: "{{ fla_ctx.system_user }}"
-        mode: "0750"
+        owner: "{{ (fla_ctx.container_uid | default('82')) if (vol.manage_owner | default(true)) else omit }}"
+        group: "{{ fla_ctx.system_user if (vol.manage_owner | default(true)) else omit }}"
+        mode: "{{ '0750' if (vol.manage_owner | default(true)) else omit }}"
       loop: "{{ fla_ctx.additional_volumes | selectattr('src', 'defined') | list }}"
       loop_control:
         loop_var: vol


### PR DESCRIPTION
## Summary
- `firth_laravel_app`'s deploy task force-sets `owner`/`group`/`mode 0750` on every `additional_volumes` `src` path on **every** playbook run, including thalium's `/home/library/RPG/Systems` bind mount.
- That path is a shared media library (not thalium-owned), previously `775` with group access for other consumers (e.g. filebot/`medialibrary`). Every thalium deploy silently reverted it back to `82:thalium:0750`, which is why permission fixes on that path kept getting undone.
- Adds a per-volume `manage_owner: false` opt-out (defaults to `true`, so existing apps are unaffected) and sets it on thalium's library mount in both prod and staging.
- Note: this only stops the *top-level directory* ownership from being reset — it does not touch anything recursively, since the underlying `ansible.builtin.file` task was never recursive (`recurse` was never set). Any recursive `82:thalium` ownership already present on files under the tree was from a prior manual fix, not this task, and isn't touched by this change.

## Test plan
- [x] `ansible-lint roles/firth_laravel_app/tasks/deploy.yml host_vars/firth.water.gkhs.net/laravel_apps.yml` — clean
- [x] `ansible-playbook --syntax-check playbook.yml` — clean
- [x] Ran the modified task in isolation against a scratch directory with `manage_owner: false` — confirmed no chown/chmod attempted, mode/group left untouched; the default (`manage_owner` unset) path still attempts to enforce ownership as before
- [ ] Apply to `firth.water.gkhs.net` and confirm `/home/library/RPG/Systems` ownership/mode is left alone on the next thalium deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)