### PR TITLE
Migrate istic.dev DNS from Route53 to Cloudflare

### DIFF
--- a/roles/firth_dns/tasks/main.yml
+++ b/roles/firth_dns/tasks/main.yml
@@ -161,8 +161,5 @@
     - aws
     - cernunnosdionysus
 
-- name: Update Route53 for istic_dev
-  ansible.builtin.include_tasks: zones_istic/istic_dev.yml
-  tags:
-    - aws
-    - istic_dev
+- name: Istic.dev DNS
+  ansible.builtin.import_tasks: zones_istic/istic_dev.yml

--- a/roles/firth_dns/tasks/zones_istic/istic_dev.yml
+++ b/roles/firth_dns/tasks/zones_istic/istic_dev.yml
@@ -1,60 +1,66 @@
 ---
 - name: Istic.dev DNS
-  tags:
-    - aws
-    - istic_dev
+  vars:
+    _zone: istic.dev
+    _records:
+      - { name: "@", type: A, state: present, value: "{{ loadbalancer_ip }}", cf_proxied: true }
+      - { name: "*", type: CNAME, state: present, value: tributary.water.gkhs.net, cf_proxied: false }
+      - { name: novelathon, type: A, state: present, value: "{{ loadbalancer_ip }}", cf_proxied: true }
+      - { name: voyeur, type: A, state: present, value: "{{ atoll_ip }}", cf_proxied: true }
+      - { name: ws.voyeur, type: A, state: present, value: "{{ atoll_ip }}", cf_proxied: true }
   block:
-    - name: Istic.dev. - A
-      amazon.aws.route53:
-        overwrite: true
-        state: present
-        zone: istic.dev
-        record: istic.dev.
-        aws_profile: istic
-        type: A
-        ttl: "300"
-        value: "{{ loadbalancer_ip }}"
+    - name: Istic.dev Route53 DNS
+      tags:
+        - aws
+        - istic_dev
+        - istic_dev_aws
+      block:
+        - name: "Istic.dev Route53 {{ item.name ~ ' ' ~ item.type }}"
+          amazon.aws.route53:
+            overwrite: true
+            state: "{{ item.state }}"
+            zone: "{{ _zone }}"
+            record: "{{ (item.name == '@') | ternary(_zone + '.', item.name + '.' + _zone + '.') }}"
+            aws_profile: istic
+            type: "{{ item.type }}"
+            ttl: "{{ item.ttl | default('300') }}"
+            value: "{{ item.value }}"
+          loop: "{{ _records | rejectattr('cf_only', 'defined') | list }}"
+          loop_control:
+            label: "{{ item.name }} {{ item.type }}"
 
-    - name: Wildcard.istic.dev. - CNAME
-      amazon.aws.route53:
-        overwrite: true
-        state: present
-        zone: istic.dev
-        record: "*.istic.dev."
-        aws_profile: istic
-        type: CNAME
-        ttl: "300"
-        value: tributary.water.gkhs.net
+      rescue:
+        - name: Failure warning
+          ansible.builtin.debug:
+            msg: AWS Route53 tasks failed
+        - name: Failure execution
+          ansible.builtin.command:
+            cmd: "false"
 
-    - name: Novelathon.istic.dev. - A
-      amazon.aws.route53:
-        overwrite: true
-        state: present
-        zone: istic.dev
-        record: novelathon.istic.dev.
-        aws_profile: istic
-        type: A
-        ttl: "300"
-        value: "{{ loadbalancer_ip }}"
+    - name: Istic.dev Cloudflare DNS
+      tags:
+        - cloudflare
+        - cloudflare_dns
+        - istic_dev
+      block:
+        - name: "(CF) Istic.dev {{ item.name ~ ' ' ~ item.type }}"
+          community.general.cloudflare_dns:
+            state: "{{ item.state }}"
+            zone: "{{ _zone }}"
+            record: "{{ item.name }}"
+            api_token: "{{ cloudflare_api_key }}"
+            type: "{{ item.type }}"
+            ttl: "{{ item.ttl | default(omit) }}"
+            value: "{{ item.value }}"
+            proxied: "{{ item.cf_proxied | default(false) }}"
+          loop: "{{ _records | rejectattr('r53_only', 'defined') | list }}"
+          loop_control:
+            label: "{{ item.name }} {{ item.type }}"
 
-    - name: Voyeur.istic.dev. - A
-      amazon.aws.route53:
-        overwrite: true
-        state: present
-        zone: istic.dev
-        record: voyeur.istic.dev.
-        aws_profile: istic
-        type: A
-        ttl: "300"
-        value: "{{ atoll_ip }}"
-
-    - name: Ws.voyeur.istic.dev. - A
-      amazon.aws.route53:
-        overwrite: true
-        state: present
-        zone: istic.dev
-        record: ws.voyeur.istic.dev.
-        aws_profile: istic
-        type: A
-        ttl: "300"
-        value: "{{ atoll_ip }}"
+      rescue:
+        - name: Failure warning
+          ansible.builtin.debug:
+            msg: Cloudflare DNS tasks failed
+        - name: Failure execution
+          ansible.builtin.command:
+            cmd: "false"

--- a/roles/firth_dns/tasks/zones_istic/istic_dev.yml
+++ b/roles/firth_dns/tasks/zones_istic/istic_dev.yml
@@ -64,3 +64,13 @@
         - name: Failure execution
           ansible.builtin.command:
             cmd: "false"
+
+    - name: Delegate istic.dev to Cloudflare on Namecheap
+      ansible.builtin.include_tasks: ../../included_tasks/namecheap_delegate.yml
+      vars:
+        namecheap_sld: istic
+        namecheap_tld: dev
+        namecheap_nameservers: carol.ns.cloudflare.com,phil.ns.cloudflare.com
+      tags:
+        - istic_dev
+        - namecheap

--- a/roles/stream_delta/tasks/general.yml
+++ b/roles/stream_delta/tasks/general.yml
@@ -56,6 +56,34 @@
       tags:
         - istic_dev
 
+    - name: "(CF) Voyeur.istic.dev - A"
+      community.general.cloudflare_dns:
+        state: present
+        zone: istic.dev
+        record: voyeur
+        api_token: "{{ cloudflare_api_key }}"
+        type: A
+        value: "{{ atoll_ip }}"
+        proxied: true
+      tags:
+        - cloudflare
+        - cloudflare_dns
+        - istic_dev
+
+    - name: "(CF) Ws.voyeur.istic.dev - A"
+      community.general.cloudflare_dns:
+        state: present
+        zone: istic.dev
+        record: ws.voyeur
+        api_token: "{{ cloudflare_api_key }}"
+        type: A
+        value: "{{ atoll_ip }}"
+        proxied: true
+      tags:
+        - cloudflare
+        - cloudflare_dns
+        - istic_dev
+
   rescue:
     - name: "Failure warning"
       ansible.builtin.debug:


### PR DESCRIPTION
## Summary
- Convert `istic_dev.yml` to the Route53+Cloudflare dual-write pattern already used for novelathon.com/aquarionics.com
- Wire up the existing Namecheap delegation task to point istic.dev at Cloudflare's nameservers (`carol.ns.cloudflare.com` / `phil.ns.cloudflare.com`)
- Add matching Cloudflare tasks to `stream_delta`'s separately-managed `voyeur.istic.dev`/`ws.voyeur.istic.dev` records so both providers stay in sync

## Status
Already run against production: Cloudflare records created, Namecheap nameservers switched, verified via dry-run + `aws route53 list-resource-record-sets` that no records were missed before cutover (istic.dev has no MX/TXT/mail records to worry about).

Route53 blocks are left in place intentionally for now (dual-write) and can be dropped once propagation is confirmed (`dig NS istic.dev`).

## Test plan
- [x] `ansible-lint` clean on all changed files
- [x] `ansible-playbook playbook.yml --tags istic_dev --check --diff` reviewed before applying
- [x] Applied for real: Cloudflare records created, Namecheap API call succeeded
- [x] `ansible-playbook playbook.yml --tags cloudflare_dns --limit atoll.water.gkhs.net --check` shows no drift for stream_delta's new tasks
- [ ] Confirm DNS propagation and drop Route53 blocks in a follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)