### PR TITLE
Move bloom staging from social.istic.dev to beta.bloomfeed.app

### DIFF
--- a/host_vars/firth.water.gkhs.net/laravel_apps.yml
+++ b/host_vars/firth.water.gkhs.net/laravel_apps.yml
@@ -157,10 +157,10 @@ firth_laravel_app_apps:
     staging:
       image_tag: staging
       port: 8001
-      server_name: social.istic.dev
-      app_url: https://social.istic.dev
+      server_name: beta.bloomfeed.app
+      app_url: https://beta.bloomfeed.app
       app_key: "{{ vault_bloom_staging_app_key }}"
-      ssl_snippet: istic_dev
+      ssl_snippet: bloomfeedapp
       mysql:
         db_name: bloom_staging
         db_user: bloom_staging

--- a/roles/firth_dns/tasks/zones_aqcom/bloomfeedapp.yml
+++ b/roles/firth_dns/tasks/zones_aqcom/bloomfeedapp.yml
@@ -47,6 +47,19 @@
   tags:
     - bloomfeedapp
 
+- name: Beta.bloomfeed.app. - A
+  amazon.aws.route53:
+    overwrite: true
+    state: present
+    zone: bloomfeed.app
+    record: beta.bloomfeed.app.
+    type: A
+    ttl: "300"
+    value: "{{ loadbalancer_ip }}"
+    aws_profile: aqcom
+  tags:
+    - bloomfeedapp
+
 - name: Delegate bloomfeed.app to Route53 on Namecheap
   ansible.builtin.include_tasks: ../../included_tasks/namecheap_delegate.yml
   vars:


### PR DESCRIPTION
## Summary
- Repoints bloom's staging entry in `host_vars/firth.water.gkhs.net/laravel_apps.yml` from `social.istic.dev` to `beta.bloomfeed.app` (`server_name`, `app_url`, and `ssl_snippet: bloomfeedapp` — reusing the existing `*.bloomfeed.app` wildcard cert instead of the shared `istic_dev` one).
- Adds the Route53 A record for `beta.bloomfeed.app` in `roles/firth_dns/tasks/zones_aqcom/bloomfeedapp.yml`, pointing at `loadbalancer_ip` like the existing `bloomfeed.app`/`www.bloomfeed.app` records.

No nginx vhost changes are needed — the `firth_laravel_app` role generates the staging vhost from `laravel_apps.yml` at deploy time, and it already inherits `ssl_snippet` correctly.

`social.istic.dev` isn't given an explicit redirect since it was only ever a wildcard (`*.istic.dev`) entry with no dedicated DNS record to clean up; it will simply stop being served once this deploys.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open(...))"` on both changed files — valid YAML
- [ ] `ansible-lint` on the changed files (not available in this environment)
- [ ] Run the `firth_dns` and `firth_laravel_app` playbooks against `firth.water.gkhs.net` to provision the new DNS record and redeploy the staging vhost/cert


---
_Generated by [Claude Code](https://claude.ai/code/session_01APGz6JyPbDWsstZr6QxQYP)_