### PR TITLE
Fix ansible.cfg interpreter_python env-var expansion

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -8,7 +8,7 @@ fact_caching_timeout = 86400
 retry_files_enabled = True
 retry_files_save_path = ~/.ansible-retry
 
-interpreter_python=$VIRTUAL_ENV/bin/python
+interpreter_python=auto_silent
 deprecation_warnings=False
 
 [ssh_connection]


### PR DESCRIPTION
## Summary
- `ansible.cfg` set `interpreter_python=$VIRTUAL_ENV/bin/python`, but Ansible's config loader doesn't shell-expand env vars in this setting, so any `delegate_to: localhost` task failed with `The module interpreter '$VIRTUAL_ENV/bin/python' was not found.`
- Switched to `interpreter_python=auto_silent` so Ansible discovers the correct interpreter per host instead of relying on broken literal env-var interpolation.

## Test plan
- [x] Confirmed `ansible.constants` resolves `INTERPRETER_PYTHON` to `auto_silent`
- [x] Reran `ansible-playbook playbook.yml --tags firth_laravel_app_install --limit firth.water.gkhs.net` — completed with `failed=0` (previously failed on the GitHub public-key lookup delegated to localhost)