### PR TITLE
Fix SFTP chroot ownership breaking connections after auth

### DIFF
--- a/roles/firth_sftp_docker/README.md
+++ b/roles/firth_sftp_docker/README.md
@@ -71,9 +71,10 @@ The role creates the following directory structure:
 ├── bin/
 │   └── bind_mounts.sh
 └── home/
-    └── <username>/         # created and chowned by sftp-sync.sh, not by Ansible
-        └── .ssh/
-            └── authorized_keys
+    └── <username>/         # created by sftp-sync.sh, kept root:root for sshd's ChrootDirectory check
+        ├── .ssh/           # user-owned; created only if a public_key is set
+        │   └── authorized_keys
+        └── files/          # user-owned; the only writable path inside the chroot by default
 ```
 
 ## Security Features
@@ -82,7 +83,7 @@ The role creates the following directory structure:
 - SSH key and/or password authentication, both sourced from Alchemistic's `sftp_users` table (password stored as SHA-512 crypt)
 - Dedicated system user runs the container
 - Proper file permissions and ownership
-- Per-user home roots are reconciled to each user UID/GID on every sync tick so content under `username/` stays user-owned
+- Per-user home roots stay `root:root` (required for sshd's `ChrootDirectory` check); content under `username/` is reconciled to each user's UID/GID on every sync tick
 - SSH host key persistence across container restarts
 - `sftp-sync.sh` reconciles unconditionally on every tick (not gated on the `dirty` flag), so a container restart/recreate doesn't strand accounts until the next unrelated data change
 

--- a/roles/firth_sftp_docker/tasks/main.yml
+++ b/roles/firth_sftp_docker/tasks/main.yml
@@ -264,6 +264,9 @@
     - sftp
     - docker
     - sftp_docker_compose
+
+  notify: Restart SFTP Docker
+
   block:
     - name: Template docker-compose.yml for SFTP Docker container
       ansible.builtin.template:

--- a/roles/firth_sftp_docker/templates/docker-compose.yml.j2
+++ b/roles/firth_sftp_docker/templates/docker-compose.yml.j2
@@ -19,9 +19,10 @@ services:
 {% endfor %}
 {% endfor %}
     logging:
-      driver: journald
+      driver: json-file
       options:
-        tag: "$${.Name}/$${.ID}"
+        max-size: "10m"
+        max-file: "3"
     networks:
       - firth_services
     restart: unless-stopped
@@ -37,9 +38,10 @@ services:
       - firth_services
     restart: unless-stopped
     logging:
-      driver: journald
+      driver: json-file
       options:
-        tag: "$${.Name}/$${.ID}"
+        max-size: "10m"
+        max-file: "3"
 {% endfor %}
 
 networks:

--- a/roles/firth_sftp_docker/templates/sftp-sync.sh.j2
+++ b/roles/firth_sftp_docker/templates/sftp-sync.sh.j2
@@ -46,9 +46,16 @@ mysql -sNe "SELECT CONCAT(username, ':', COALESCE(NULLIF(password, ''), '*'), ':
 # was invisible while there was ever only one row to reconcile.
 while IFS= read -r line; do
     username="${line%%:*}"
-    if ! docker compose -f "$SFTP_DIR/docker-compose.yml" exec -T sftp \
-            /usr/local/bin/create-sftp-user "$line" < /dev/null; then
+    hash="${line#*:}"; hash="${hash%%:*}"
+    # create-sftp-user logs its raw argument (including the password hash) to
+    # stdout on every call; capture it instead of letting it flow straight to
+    # the journal, and only print it if the call actually failed - with the
+    # hash redacted even then, since failing ticks are the ones most likely
+    # to get copied into a chat or issue.
+    if ! output=$(docker compose -f "$SFTP_DIR/docker-compose.yml" exec -T sftp \
+            /usr/local/bin/create-sftp-user "$line" < /dev/null 2>&1); then
         echo "ERROR: create-sftp-user failed for user: $username" >&2
+        echo "${output//"$hash"/<redacted>}" >&2
         exit 1
     fi
 done < "$USERS_CONF"
@@ -78,7 +85,21 @@ while IFS=$'\t' read -r username uid gid public_key; do
     auth_keys="$ssh_dir/authorized_keys"
 
     mkdir -p "$user_home"
-    chown -R "$uid:$gid" "$user_home"
+    # The chroot directory itself must stay root:root, not-group/other-writable,
+    # or sshd rejects it post-auth ("bad ownership or modes for chroot directory")
+    # and drops the connection before the SFTP subsystem opens - this is sshd's
+    # requirement, not atmoz/sftp's, so it holds regardless of image version.
+    # Only content *under* the home dir should be user-owned.
+    chown root:root "$user_home"
+    chmod 755 "$user_home"
+
+    # Users need somewhere writable inside the chroot - the chroot root itself
+    # can't be it. Bind mounts / PHP sites (if configured) provide their own
+    # writable subdirs, but every user gets this one regardless so plain
+    # SFTP-only accounts aren't left unable to upload anything.
+    mkdir -p "$user_home/files"
+
+    find "$user_home" -mindepth 1 -maxdepth 1 -exec chown -R "$uid:$gid" {} +
 
     if [[ -n "$public_key" ]]; then
         mkdir -p "$ssh_dir"


### PR DESCRIPTION
## Summary
- `sftp-sync.sh` was recursively chowning each user's chroot root (`/home/<user>`) to the user's own uid/gid on every sync tick. sshd rejects that ("bad ownership or modes for chroot directory") and disconnects immediately after a successful password auth - this was the root cause of a reported issue where a user (kastark) could authenticate successfully in FileZilla/WinSCP but the connection would then drop before the SFTP subsystem opened.
- Chroot root now stays `root:root`/`0755` (matching what atmoz/sftp's own `create-sftp-user` does for freshly created users), with a user-owned `files/` subdirectory added so accounts still have somewhere writable inside the chroot.
- Stopped leaking the SHA-512 password hash into the `sftp-sync` systemd journal on every tick - `create-sftp-user`'s own stdout logs its raw argument (including the hash); this is now captured and only surfaced (redacted) on failure.
- Switched the `sftp`/`phpfpm_*` containers from `journald` to `json-file` logging, matching the `firth_laravel_app` convention, so SigNoz's `filelog` receiver (which tails `/var/lib/docker/containers/*/*-json.log`) picks these containers up automatically.
- Added the missing `notify: Restart SFTP Docker` on the docker-compose template task so the logging-driver change actually gets applied on deploy.

## Test plan
- [x] `ansible-lint` and `shellcheck` clean
- [x] Dry-run (`--check --diff`) against firth showed only the intended changes
- [x] Deployed to firth; confirmed `kastark`'s (and other users') home dirs are now `root:root` with a user-owned `files/` subdir
- [x] Confirmed via container logs: `Accepted password` no longer followed by `bad ownership or modes for chroot directory`
- [x] Live end-to-end test with the `aquarion` account: password auth succeeds, SFTP subsystem opens, `mkdir`/`rmdir` under `files/` works, clean disconnect
- [x] Confirmed `sftp-sync.service` journal no longer contains the password hash on routine ticks
- [x] Confirmed json-file log for the sftp container is being written
- [ ] Awaiting confirmation from kastark (contacted separately) that their client now connects successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)