### PR TITLE
Add host metrics to SigNoz for firth and atoll

### DIFF
--- a/host_vars/firth.water.gkhs.net/signoz.yml
+++ b/host_vars/firth.water.gkhs.net/signoz.yml
@@ -6,3 +6,9 @@ signoz_ingester_hostname: ingester
 # signoz_ingester_scheme: http
 # signoz_ingester_is_insecure: "true"
 # signoz_ingester_default_protocol: http/protobuf
+
+# otel_hostmetrics runs on firth itself, so it can skip the public
+# otel_agents_ingest vhost and hit the ingester's localhost-published OTLP/HTTP
+# port directly (see roles/firth_signoz/templates/casting.yaml.j2).
+otel_hostmetrics_otlp_endpoint: "http://127.0.0.1:4318"
+otel_hostmetrics_otlp_insecure: true

--- a/playbook.yml
+++ b/playbook.yml
@@ -84,6 +84,7 @@
     - firth_sftp_docker
     - firth_elasticsearch
     - firth_signoz
+    - otel_hostmetrics
     - firth_laravel_app
     - firth_laravel_app_remove
 
@@ -101,4 +102,5 @@
     - aws_profiles
     - geerlingguy.nodejs
     - firth_docker
+    - otel_hostmetrics
     - stream_delta

--- a/roles/firth_dns/tasks/zones_istic/istic.yml
+++ b/roles/firth_dns/tasks/zones_istic/istic.yml
@@ -661,6 +661,19 @@
       tags:
         - istic_sys
 
+    - name: "OTel Agents DNS"
+      amazon.aws.route53:
+        overwrite: true
+        state: present
+        zone: istic.systems
+        record: otel-agents.svc.istic.systems.
+        type: A
+        ttl: "300"
+        value: "{{ loadbalancer_ip }}"
+        aws_profile: istic
+      tags:
+        - istic_sys
+
   rescue:
     - name: "Failure warning"
       ansible.builtin.debug:

--- a/roles/firth_nginx/templates/vhosts/otel_agents_ingest
+++ b/roles/firth_nginx/templates/vhosts/otel_agents_ingest
@@ -20,6 +20,11 @@ server {
         allow {{ atoll_ip }};
         deny all;
 
+        # OTLP/HTTP ingestion is POST-only - matches otlp_ingest.
+        if ($request_method != POST) {
+            return 405;
+        }
+
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;

--- a/roles/firth_nginx/templates/vhosts/otel_agents_ingest
+++ b/roles/firth_nginx/templates/vhosts/otel_agents_ingest
@@ -1,0 +1,29 @@
+# {{ ansible_managed }}
+
+# Internal-only OTLP/HTTP ingestion endpoint for OTel collectors running on
+# other hosts in the fleet (e.g. atoll's otel_hostmetrics agent) that have no
+# private network path back to firth's ingester. IP-allowlisted, not for
+# public/browser use - see the separate otlp_ingest vhost for that. #265.
+server {
+
+    server_name             otel-agents.svc.istic.systems;
+
+    listen 443 ssl proxy_protocol;
+    listen [::]:443 ssl proxy_protocol;
+
+    client_max_body_size 2m;
+
+    add_header X-WhyAmI OtelAgentsIngest;
+    include /etc/nginx/snippets/ssl/svc_istic_systems_ssl.conf;
+
+    location / {
+        allow {{ atoll_ip }};
+        deny all;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_pass http://127.0.0.1:4318;
+    }
+}

--- a/roles/otel_hostmetrics/defaults/main.yml
+++ b/roles/otel_hostmetrics/defaults/main.yml
@@ -1,0 +1,13 @@
+---
+otel_hostmetrics_image: otel/opentelemetry-collector-contrib
+otel_hostmetrics_image_tag: latest
+otel_hostmetrics_collection_interval: 60s
+otel_hostmetrics_root: "{{ docker_root }}/otel-hostmetrics"
+
+# Default targets the public internal-only otel_agents_ingest nginx vhost
+# (roles/firth_nginx/templates/vhosts/otel_agents_ingest), for hosts that
+# aren't firth itself and so can't reach the ingester over the docker
+# network. Firth overrides these to hit the ingester's localhost-published
+# port directly - see host_vars/firth.water.gkhs.net/signoz.yml.
+otel_hostmetrics_otlp_endpoint: "https://otel-agents.svc.istic.systems"
+otel_hostmetrics_otlp_insecure: false

--- a/roles/otel_hostmetrics/tasks/main.yml
+++ b/roles/otel_hostmetrics/tasks/main.yml
@@ -1,0 +1,38 @@
+---
+- name: Deploy OTel host metrics collector
+  tags: [otel_hostmetrics]
+  become: true
+  block:
+    - name: Ensure otel-hostmetrics directory exists
+      ansible.builtin.file:
+        path: "{{ otel_hostmetrics_root }}"
+        state: directory
+        owner: root
+        group: root
+        mode: "0750"
+
+    - name: Template otel-hostmetrics collector config
+      ansible.builtin.template:
+        src: config.yaml.j2
+        dest: "{{ otel_hostmetrics_root }}/config.yaml"
+        owner: root
+        group: root
+        mode: "0640"
+      register: otel_hostmetrics_config
+
+    - name: Template otel-hostmetrics docker-compose.yml
+      ansible.builtin.template:
+        src: docker-compose.yml.j2
+        dest: "{{ otel_hostmetrics_root }}/docker-compose.yml"
+        owner: root
+        group: root
+        mode: "0640"
+        validate: docker compose -f %s config -q
+      register: otel_hostmetrics_compose_file
+
+    - name: Pull and start otel-hostmetrics
+      community.docker.docker_compose_v2:
+        project_src: "{{ otel_hostmetrics_root }}"
+        pull: always
+        state: present
+        recreate: "{{ 'always' if (otel_hostmetrics_config.changed or otel_hostmetrics_compose_file.changed) else 'auto' }}"

--- a/roles/otel_hostmetrics/templates/config.yaml.j2
+++ b/roles/otel_hostmetrics/templates/config.yaml.j2
@@ -9,14 +9,17 @@ receivers:
       memory: {}
       disk: {}
       filesystem:
+        # Mount points here are the host's own (as read from its /proc/mounts
+        # via root_path), not prefixed with /hostfs - that prefix only applies
+        # to where the receiver itself reads host files from inside the container.
         exclude_mount_points:
           match_type: regexp
           mount_points:
-            - /hostfs/var/lib/docker/.*
-            - /hostfs/proc/.*
-            - /hostfs/sys/.*
-            - /hostfs/dev/.*
-            - /hostfs/run/.*
+            - /var/lib/docker/.*
+            - /proc/.*
+            - /sys/.*
+            - /dev/.*
+            - /run/.*
         exclude_fs_types:
           match_type: strict
           fs_types:

--- a/roles/otel_hostmetrics/templates/config.yaml.j2
+++ b/roles/otel_hostmetrics/templates/config.yaml.j2
@@ -1,0 +1,71 @@
+# {{ ansible_managed }}
+receivers:
+  hostmetrics:
+    root_path: /hostfs
+    collection_interval: "{{ otel_hostmetrics_collection_interval }}"
+    scrapers:
+      cpu: {}
+      load: {}
+      memory: {}
+      disk: {}
+      filesystem:
+        exclude_mount_points:
+          match_type: regexp
+          mount_points:
+            - /hostfs/var/lib/docker/.*
+            - /hostfs/proc/.*
+            - /hostfs/sys/.*
+            - /hostfs/dev/.*
+            - /hostfs/run/.*
+        exclude_fs_types:
+          match_type: strict
+          fs_types:
+            - autofs
+            - binfmt_misc
+            - bpf
+            - cgroup2
+            - configfs
+            - debugfs
+            - devpts
+            - devtmpfs
+            - fusectl
+            - hugetlbfs
+            - mqueue
+            - nsfs
+            - overlay
+            - proc
+            - pstore
+            - securityfs
+            - selinuxfs
+            - squashfs
+            - sysfs
+            - tracefs
+      network: {}
+      paging: {}
+      processes: {}
+
+processors:
+  # Explicit host.name instead of relying on resourcedetection - the
+  # container's own hostname resolution isn't reliably the real host's
+  # identity, and we only ever run this against two known hosts.
+  resource:
+    attributes:
+      - key: host.name
+        value: "{{ inventory_hostname }}"
+        action: upsert
+  batch:
+    send_batch_size: 10000
+    timeout: 10s
+
+exporters:
+  otlphttp:
+    endpoint: "{{ otel_hostmetrics_otlp_endpoint }}"
+    tls:
+      insecure: {{ 'true' if otel_hostmetrics_otlp_insecure else 'false' }}
+
+service:
+  pipelines:
+    metrics:
+      receivers: [hostmetrics]
+      processors: [resource, batch]
+      exporters: [otlphttp]

--- a/roles/otel_hostmetrics/templates/docker-compose.yml.j2
+++ b/roles/otel_hostmetrics/templates/docker-compose.yml.j2
@@ -1,0 +1,16 @@
+# {{ ansible_managed }}
+services:
+  otel-hostmetrics:
+    image: "{{ otel_hostmetrics_image }}:{{ otel_hostmetrics_image_tag }}"
+    hostname: "{{ inventory_hostname }}"
+    restart: unless-stopped
+    # host networking + pid so the hostmetrics receiver sees the real host's
+    # interfaces/processes rather than this container's own, and so firth can
+    # reach the ingester on 127.0.0.1 without joining its docker network.
+    network_mode: host
+    pid: host
+    user: root
+    volumes:
+      - ./config.yaml:/etc/otelcol-contrib/config.yaml:ro
+      - /:/hostfs:ro
+    command: ["--config=/etc/otelcol-contrib/config.yaml"]


### PR DESCRIPTION
## Summary

Closes #265. (Issue had no description — scoped this after confirming with @aquarion that both `firth` and `atoll` should be covered.)

- New `roles/otel_hostmetrics` role deploys a standalone OTel Collector on each host, using the `hostmetrics` receiver (cpu/memory/disk/filesystem/network/load/processes), following the "Docker Collection Agent" pattern from SigNoz's own docs rather than bolting this onto the existing ingester config.
- Runs with `network_mode: host` + `pid: host` and `/:/hostfs:ro` mounted, so it observes the real host rather than its own container namespace — this matters most for the `network` scraper, which would otherwise only see the container's own virtual interface.
- **Firth** exports straight to the ingester's localhost-published OTLP/HTTP port (`127.0.0.1:4318`, published in #278) via a host_vars override in `signoz.yml`.
- **Atoll** has no private network path to firth's ingester — there's no VPN/private network between these hosts anywhere in this repo, they're separate public IPs. So it needs a new nginx vhost on firth: `roles/firth_nginx/templates/vhosts/otel_agents_ingest`, IP-allowlisted to `atoll_ip` (`allow`/`deny`, no CORS — this isn't browser traffic). Deliberately a separate vhost/hostname (`otel-agents.svc.istic.systems`) from the public browser-facing `otlp_ingest` vhost from #268, since that one is CORS-gated for browsers and wouldn't make sense (or wouldn't need to be public) for a metrics collector.
- New DNS record `otel-agents.svc.istic.systems` → `loadbalancer_ip`, routed through the LB with `proxy_protocol` like every other firth vhost (consistent with the fix in #278).
- `host.name` is set explicitly via a `resource` processor (`inventory_hostname`) rather than relying on `resourcedetection`, since container hostname resolution isn't reliably the real host's identity and we only ever run this against two known hosts.

## Notes / things to verify on deploy

- I don't have a way to run this collector or start nginx in this sandbox — reviewed by hand against SigNoz/OTel Collector docs and existing patterns in this repo (e.g. `firth_laravel_app`'s `community.docker.docker_compose_v2` usage), not executed.
- `otel/opentelemetry-collector-contrib:latest` is unpinned, matching this repo's existing risk tolerance for `firth_signoz`'s own `foundryctl` install (fetches `latest` GitHub release). Worth pinning a version if that's a concern.
- Rate limiting was deliberately skipped on `otel_agents_ingest` (unlike the public `otlp_ingest` vhost) since it's IP-allowlisted to exactly one known caller — flagging in case that reasoning doesn't hold up.

## Test plan

- [ ] `ansible-playbook --check` (or full run) against firth and atoll to confirm no syntax errors
- [ ] `docker compose ps` / logs on both hosts to confirm `otel-hostmetrics` starts cleanly and isn't erroring on `/hostfs` reads
- [ ] Confirm host metrics for both `firth.water.gkhs.net` and `atoll.water.gkhs.net` show up distinctly in SigNoz's Infrastructure Monitoring view
- [ ] Confirm atoll's export path actually reaches firth through the new vhost (check `otel-hostmetrics` container logs for export errors, and firth's nginx access logs for the allowlisted requests)
- [ ] Confirm a request to `otel-agents.svc.istic.systems` from a non-allowlisted IP is rejected

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4KgAWYucQfZ8PPbvt7Hoo)_