### PR TITLE
Fix otel-hostmetrics failing to start on firth and atoll

### DIFF
--- a/host_vars/atoll.water.gkhs.net/docker.yml
+++ b/host_vars/atoll.water.gkhs.net/docker.yml
@@ -1,0 +1,2 @@
+---
+docker_root: /srv/docker

--- a/roles/firth_docker/tasks/main.yml
+++ b/roles/firth_docker/tasks/main.yml
@@ -48,6 +48,14 @@
         - docker-ce
         - docker-ce-cli
 
+    - name: Ensure docker_root exists
+      ansible.builtin.file:
+        path: "{{ docker_root }}"
+        state: directory
+        owner: root
+        group: docker
+        mode: "0775"
+
     - name: Allow docker to access redis
       ansible.builtin.lineinfile:
         path: /etc/redis/redis.conf

--- a/roles/otel_hostmetrics/templates/docker-compose.yml.j2
+++ b/roles/otel_hostmetrics/templates/docker-compose.yml.j2
@@ -9,7 +9,7 @@ services:
     # reach the ingester on 127.0.0.1 without joining its docker network.
     network_mode: host
     pid: host
-    user: root
+    user: "0"
     volumes:
       - ./config.yaml:/etc/otelcol-contrib/config.yaml:ro
       - /:/hostfs:ro


### PR DESCRIPTION
## Summary
- `otel-hostmetrics` failed to start on firth: `docker-compose.yml.j2` set `user: root`, but the `otel/opentelemetry-collector-contrib` image has no `/etc/passwd` entry for the name `root`, so Docker couldn't resolve it. Switched to the numeric UID (`user: "0"`).
- `otel-hostmetrics` also failed on atoll (separate bug): `docker_root` was never defined for atoll (only firth had it, via vault), and no role actually created the `docker_root` directory itself — it just happened to pre-exist on firth. Added `docker_root: /srv/docker` to atoll's host_vars, and a task in `firth_docker` (runs on both hosts) to ensure the directory exists.

## Test plan
- [x] Ran `ansible-playbook playbook.yml -t otel_hostmetrics,docker` against firth and atoll
- [x] Verified `otel-hostmetrics-otel-hostmetrics-1` container is `Up` on both hosts