### PR TITLE
sync_or_swim: match Show (Year) destinations to plain-named TV/ source

### DIFF
--- a/roles/water_gkhs_filebot/templates/sync_or_swim.j2.sh
+++ b/roles/water_gkhs_filebot/templates/sync_or_swim.j2.sh
@@ -103,6 +103,12 @@ for dir in "$MEDIAHOME"/*; do
 		if [[ -d "$MEDIAHOME/$SOURCEDIR/$show" ]]; then
 			debug_out "   - Syncing " "$SOURCEDIR"/"$show" " -> " "$dir"/"$show"
 			merge_dir "$MEDIAHOME/$SOURCEDIR/$show" "$dir/$show" || ((TOTAL_FAILURES++))
+		elif [[ "$show" =~ ^(.*)\ \([0-9]{4}\)$ ]] && [[ -d "$MEDIAHOME/$SOURCEDIR/${BASH_REMATCH[1]}" ]]; then
+			# Destination is named "Show (Year)" but filebot drops new
+			# downloads under the plain "Show" name in TV/ - match on the
+			# year-stripped name so those don't pile up unsynced.
+			debug_out "   - Syncing (year-stripped) " "$SOURCEDIR"/"${BASH_REMATCH[1]}" " -> " "$dir"/"$show"
+			merge_dir "$MEDIAHOME/$SOURCEDIR/${BASH_REMATCH[1]}" "$dir/$show" || ((TOTAL_FAILURES++))
 		fi
 	done < <(find -L "$dir" -maxdepth 1 -mindepth 1 -type d -print0)
 done


### PR DESCRIPTION
## Summary
- `filebot` names series without a year in `TV/` (e.g. `TV/Star Trek Strange New Worlds`), but a destination library folder can be renamed to include one (`Star-Trek/Star Trek - Strange New Worlds (2022)`).
- `sync_or_swim.sh` only merged when the `TV/` folder name matched the destination folder name exactly, so once a show's destination folder got a `(Year)` suffix, newly downloaded episodes stopped syncing out of `TV/` and stray metadata-only folders kept reappearing under the old plain name.
- Added a fallback match: when a destination folder is named `Show (Year)`, also look for the year-stripped plain name in `TV/` and merge from there.

## Test plan
- [x] `bash -n` syntax check on the modified script
- [ ] Deploy via Ansible and confirm the next filebot cron run merges pending Star Trek episodes out of `TV/` into their `(Year)` folders in `Star-Trek/`